### PR TITLE
Hardening fixes: unblock script load, fix LDIF/CSV bugs, refresh docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,99 @@
+# Changelog
+
+All notable changes to PSldap are documented here.
+
+## [0.2.1] - 2026-04-25
+
+Hardening release: removes a latent script-load failure, fixes RFC
+compliance gaps, and improves cross-runtime determinism. No new modules
+required — the script still relies only on .NET BCL assemblies that
+ship with Windows.
+
+### Fixed
+
+- **Script-load failure (regression blocker).** The param block declared
+  case-conflicting aliases — `-Z` / `-z`, `-A` / `-a`, `-S` / `-s` —
+  which PowerShell treats as duplicates because parameter aliases are
+  case-insensitive. The script failed to parse on every invocation with
+  `The alias "z" is declared multiple times`. Removed the uppercase
+  aliases; use `-useSSL`, `-typesOnly`, and `-sortOrder` (the full
+  names) in place of ldapsearch's `-Z`, `-A`, `-S`.
+- **`LinkedHashSet` runtime crash on CSV / tab output.** When CSV or
+  tab output was requested without `-requestedAttribute`, the column-
+  inference path tried to instantiate
+  `[System.Collections.Generic.LinkedHashSet[string]]` — a Java type
+  that does not exist in .NET. Replaced with a `HashSet[string]` +
+  `List[string]` pair to preserve insertion order without the missing
+  type.
+- **LDIF `dn::` Base64 encoding (RFC 2849).** DNs containing leading
+  spaces, non-ASCII, or control characters were emitted as plain
+  `dn: <raw>` instead of `dn:: <base64>`. Routed the DN line through
+  the same `Test-NeedsBase64` check used for attribute values.
+- **Scramble determinism on PowerShell 7+.** `Invoke-ScrambleValue` used
+  `String.GetHashCode()`, which is randomized per process on
+  .NET Core / .NET 5+. Scrambled output therefore differed between
+  runs on PowerShell 7. Replaced with a stable MD5-derived Int32 hash
+  (`Get-StableStringHash`) — non-cryptographic use, native to .NET, no
+  module install. Output is now reproducible across runs and across
+  Windows PowerShell 5.1 ↔ PowerShell 7+.
+- **UTF-8 BOM in file output.** `Out-File -Encoding UTF8` writes a BOM
+  on Windows PowerShell 5.1, breaking strict LDIF consumers (RFC 2849
+  forbids the BOM) and tripping up many CSV parsers. File output now
+  goes through `[System.IO.File]::WriteAllText` with
+  `UTF8Encoding($false)`.
+
+### Changed
+
+- **Test harness no longer regex-extracts function definitions.**
+  `psldap.Tests.ps1` now dot-sources `psldap.ps1`. The script's main
+  execution block is guarded with
+  `if ($MyInvocation.InvocationName -eq '.') { return }` so dot-sourcing
+  loads helpers without firing connection / search logic. The previous
+  approach broke whenever the source file's section banners were
+  reformatted.
+
+### Documentation
+
+- Rewrote `README.md` to describe the current ldapsearch-style tool
+  (the previous README still referenced the pre-uplift script that was
+  removed in `957ef17`).
+- Added this changelog.
+
+### Tests
+
+- Added a positive `dn::` Base64 LDIF test and a negative test
+  asserting plain `dn:` for printable-ASCII DNs (the previous edge-case
+  test was a false positive).
+- Test suite: **90 / 90** passing across 3 stability iterations.
+
+## [0.2.0] - prior
+
+Major uplift to an `ldapsearch`-style query tool with security
+hardening (commit `f9d6b45`). This was a near-complete rewrite of the
+original script. Highlights:
+
+- Switched from interactive prompting + `Get-ADUser` (which required
+  the ActiveDirectory module) to direct
+  `System.DirectoryServices.Protocols` calls with no module
+  dependency.
+- Full ldapsearch-style parameter surface: connection, search,
+  output, and transformation options.
+- Output formats: LDIF, JSON, CSV, multi-valued CSV, tab-delimited,
+  multi-valued tab-delimited, dns-only, values-only.
+- Paged results, server-side sorting, alias dereferencing, time /
+  size limits, rate limiting, dry-run mode.
+- File-based input: filter files (one filter per line) and LDAP-URL
+  files (multiple searches with per-search baseDN / scope /
+  attributes / filter).
+- Transformations: `-excludeAttribute`, `-redactAttribute`,
+  `-scrambleAttribute`.
+- Security hardening: `SecureString` end-to-end, byte-array zeroing
+  of password material in `finally`, mutually-exclusive credential
+  options, basic LDAP-filter syntax validation.
+- Built-in lightweight test harness (no Pester required).
+
+## [v0.1-alpha] - 2023-04-16
+
+Original `Get-ADUser`-based script that prompted the user for an LDAP
+filter and queried the current AD domain. Required the
+`ActiveDirectory` module.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,121 @@
 # PSldap
-Powershell Script to query current AD via ldap filter
-This script imports the ActiveDirectory module and gets the current domain name. It then sets a default LDAP filter of (objectClass=user) and prompts the user to customize it. If the user enters a custom filter, it uses that instead of the default.
 
-The script then builds a search query using the domain name and LDAP filter, executes the query, and displays the results.
+A PowerShell implementation inspired by the `ldapsearch` command-line tool.
+Query any LDAP directory server using custom filters, scopes, and attribute
+selections — with SSL/TLS, StartTLS, paged results, server-side sorting,
+multiple output formats, and value transformations (exclude / redact /
+scramble).
+
+## Requirements
+
+- Windows PowerShell **5.1** (or PowerShell 7+).
+- **No PowerShell modules to install.** The script uses only .NET BCL
+  assemblies that ship with Windows
+  (`System.DirectoryServices.Protocols`, `System.Net`).
+
+## Installation
+
+Download or clone the repository — there is no install step.
+
+```
+git clone https://github.com/kj299/PSldap.git
+```
+
+Or just copy [psldap.ps1](psldap.ps1) anywhere on disk.
+
+## Quick start
+
+```powershell
+# Anonymous bind, default filter, auto-detect domain & baseDN
+.\psldap.ps1
+
+# Specific server, filter, and attributes
+.\psldap.ps1 -hostname ldap.example.com `
+             -baseDN "dc=example,dc=com" `
+             -filter "(objectClass=user)" `
+             -requestedAttribute cn,mail
+
+# LDAPS with credentials, prompted for password
+.\psldap.ps1 -hostname ldap.example.com -port 636 -useSSL -trustAll `
+             -bindDN "cn=admin,dc=example,dc=com" -promptForBindPassword `
+             -baseDN "dc=example,dc=com" -filter "(uid=jdoe)" `
+             -outputFormat JSON
+
+# Read filters from a file, write CSV
+.\psldap.ps1 -filterFile .\filters.txt `
+             -baseDN "dc=example,dc=com" `
+             -outputFormat CSV `
+             -requestedAttribute cn,mail,telephoneNumber `
+             -outputFile results.csv
+
+# Multiple searches via LDAP-URL file
+.\psldap.ps1 -ldapURLFile .\urls.txt -outputFormat LDIF -continueOnError
+```
+
+Run `Get-Help .\psldap.ps1 -Detailed` for the full parameter reference.
+
+## Output formats
+
+`LDIF` (default), `JSON`, `CSV`, `multi-valued-csv`, `tab-delimited`,
+`multi-valued-tab-delimited`, `dns-only`, `values-only`.
+
+LDIF output is RFC 2849-compliant: long lines wrap with leading-space
+continuation, values requiring it are Base64-encoded (including the
+`dn::` line when the DN contains characters that need encoding).
+
+File output is written as **UTF-8 without BOM** so downstream LDIF / CSV
+consumers don't choke on the byte-order mark that Windows PowerShell 5.1
+otherwise prepends.
+
+## Security notes
+
+- Bind passwords are handled as `SecureString` end-to-end. Plaintext
+  passwords are never held in memory longer than necessary; password file
+  bytes and decoded characters are zeroed in `finally` blocks.
+- Use `-promptForBindPassword` (interactive `Read-Host -AsSecureString`),
+  `-bindPasswordFile <path>`, or `-bindPassword <SecureString>`. These
+  three options are mutually exclusive.
+- `-trustAll` disables certificate validation; use only against test
+  servers with self-signed certs.
+- The `-redactAttribute` and `-scrambleAttribute` options let you share
+  query output without exposing sensitive attribute values. Scrambling
+  is deterministic across runs (uses a stable MD5-derived hash, so
+  results are reproducible on both Windows PowerShell 5.1 and PowerShell
+  7+).
+
+## ldapsearch parameter aliases
+
+Most short-form flags from `ldapsearch` are available as PowerShell
+aliases:
+
+| Alias | Parameter             | Alias | Parameter            |
+|-------|-----------------------|-------|----------------------|
+| `-h`  | `-hostname`           | `-b`  | `-baseDN`            |
+| `-p`  | `-port`               | `-s`  | `-scope`             |
+| `-D`  | `-bindDN`             | `-z`  | `-sizeLimit`         |
+| `-w`  | `-bindPassword`       | `-l`  | `-timeLimitSeconds`  |
+| `-j`  | `-bindPasswordFile`   | `-a`  | `-dereferencePolicy` |
+| `-q`  | `-useStartTLS`        | `-f`  | `-filterFile`        |
+| `-X`  | `-trustAll`           | `-c`  | `-continueOnError`   |
+| `-r`  | `-ratePerSecond`      | `-n`  | `-dryRun`            |
+| `-T`  | `-dontWrap`           |       |                      |
+
+Note: PowerShell parameter aliases are case-insensitive, so the
+ldapsearch flags `-Z`, `-A`, and `-S` are not aliases — use the full
+parameter names `-useSSL`, `-typesOnly`, and `-sortOrder` instead.
+
+## Testing
+
+A built-in lightweight test harness runs without Pester or any other
+external module:
+
+```powershell
+.\run-tests.ps1                # 3 iterations (default)
+.\run-tests.ps1 -Iterations 1  # quick smoke test
+```
+
+On Windows you can also double-click [run-tests.bat](run-tests.bat).
+
+## License
+
+See repository for license terms.

--- a/psldap.Tests.ps1
+++ b/psldap.Tests.ps1
@@ -89,27 +89,10 @@ function Reset-TestResults {
 # ============================================================================
 # Load functions from psldap.ps1
 # ============================================================================
+# psldap.ps1 short-circuits its Main Execution block when dot-sourced
+# ($MyInvocation.InvocationName -eq '.'), so dot-sourcing only loads helpers.
 
-Add-Type -AssemblyName System.DirectoryServices.Protocols
-Add-Type -AssemblyName System.Net
-
-$scriptPath = Join-Path $PSScriptRoot 'psldap.ps1'
-$scriptContent = Get-Content -Path $scriptPath -Raw
-
-$functionsStart = $scriptContent.IndexOf('function Test-LdapFilter')
-if ($functionsStart -lt 0) {
-    $functionsStart = $scriptContent.IndexOf('function Get-BindCredential')
-}
-$mainExecMatch = [regex]::Match($scriptContent, '# =+\r?\n# Main Execution')
-$functionsEnd = if ($mainExecMatch.Success) { $mainExecMatch.Index } else { -1 }
-
-if ($functionsStart -gt 0 -and $functionsEnd -gt $functionsStart) {
-    $functionBlock = $scriptContent.Substring($functionsStart, $functionsEnd - $functionsStart)
-    . ([ScriptBlock]::Create($functionBlock))
-}
-else {
-    throw "Could not extract function definitions from psldap.ps1"
-}
+. (Join-Path $PSScriptRoot 'psldap.ps1')
 
 # ============================================================================
 # Test-LdapFilter Tests
@@ -705,10 +688,19 @@ Describe 'Edge Cases' {
         Assert-Equal '!' $result[-1]
     }
 
-    It 'Format-LdifOutput handles DN that needs Base64 encoding' {
+    It 'Format-LdifOutput Base64-encodes DN that needs encoding' {
         $entries = @([ordered]@{ dn = ' cn=leading space,dc=com'; cn = @('test') })
         $result = Format-LdifOutput -Entries $entries -WrapCol 76 -Terse
-        Assert-Match $result 'dn: '
+        Assert-Match $result '(?m)^dn:: '
+        $expected = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(' cn=leading space,dc=com'))
+        Assert-Match $result ([regex]::Escape($expected))
+    }
+
+    It 'Format-LdifOutput emits plain dn: for printable ASCII DN' {
+        $entries = @([ordered]@{ dn = 'cn=plain,dc=com'; cn = @('test') })
+        $result = Format-LdifOutput -Entries $entries -WrapCol 76 -Terse
+        Assert-Match $result '(?m)^dn: cn=plain,dc=com'
+        Assert-NotMatch $result '(?m)^dn:: '
     }
 
     It 'Format-JsonOutput handles entries with empty attribute arrays' {

--- a/psldap.ps1
+++ b/psldap.ps1
@@ -178,7 +178,9 @@ param (
 
     [switch]$promptForBindPassword,
 
-    [Alias('Z')]
+    # Note: ldapsearch uses '-Z' for StartTLS, but PowerShell aliases are
+    # case-insensitive — '-Z' would collide with '-z' (sizeLimit). Use the
+    # full -useSSL / -useStartTLS names instead.
     [switch]$useSSL,
 
     [Alias('q')]
@@ -207,7 +209,9 @@ param (
     [ValidateSet('never', 'always', 'search', 'find')]
     [string]$dereferencePolicy = 'never',
 
-    [Alias('A')]
+    # Note: ldapsearch uses '-A' for typesOnly, but PowerShell aliases are
+    # case-insensitive — '-A' would collide with '-a' (dereferencePolicy).
+    # Use the full -typesOnly name instead.
     [switch]$typesOnly,
 
     [string[]]$filter,
@@ -277,7 +281,9 @@ param (
 
     [switch]$terse,
 
-    [Alias('S')]
+    # Note: ldapsearch uses '-S' for sortOrder, but PowerShell aliases are
+    # case-insensitive — '-S' would collide with '-s' (scope). Use the
+    # full -sortOrder name instead.
     [string]$sortOrder,
 
     [ValidateRange(1, [int]::MaxValue)]
@@ -567,6 +573,29 @@ function ConvertTo-TransformedEntry {
     return $result
 }
 
+function Get-StableStringHash {
+    <#
+    .SYNOPSIS
+        Returns a stable Int32 hash of a string. Used instead of String.GetHashCode()
+        because that is randomized per-process on .NET Core / PowerShell 7+,
+        which would break cross-run determinism of scrambled values.
+        Uses MD5 (non-cryptographic use — just a stable mixer). Native to .NET, no module install.
+    #>
+    param([string]$Value)
+
+    if ([string]::IsNullOrEmpty($Value)) { return 0 }
+
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($Value)
+    $md5 = [System.Security.Cryptography.MD5]::Create()
+    try {
+        $hashBytes = $md5.ComputeHash($bytes)
+        return [BitConverter]::ToInt32($hashBytes, 0)
+    }
+    finally {
+        $md5.Dispose()
+    }
+}
+
 function Invoke-ScrambleValue {
     <#
     .SYNOPSIS
@@ -578,8 +607,8 @@ function Invoke-ScrambleValue {
         [int]$Seed
     )
 
-    # Combine seed with a hash of the value for deterministic per-value scrambling
-    $valueHash = $Value.GetHashCode()
+    # Combine seed with a stable hash of the value for cross-run deterministic scrambling.
+    $valueHash = Get-StableStringHash -Value $Value
     $rng = [System.Random]::new($Seed -bxor $valueHash)
 
     $chars = $Value.ToCharArray()
@@ -676,7 +705,13 @@ function Format-LdifOutput {
     }
 
     foreach ($entry in $Entries) {
-        $dnLine = "dn: $($entry.dn)"
+        if (Test-NeedsBase64 -Value $entry.dn) {
+            $dnB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($entry.dn))
+            $dnLine = "dn:: $dnB64"
+        }
+        else {
+            $dnLine = "dn: $($entry.dn)"
+        }
         if ($NoWrap) {
             [void]$sb.AppendLine($dnLine)
         }
@@ -888,7 +923,11 @@ function Write-SearchOutput {
     }
 
     if ($OutFile) {
-        $output | Out-File -FilePath $OutFile -Encoding UTF8 -NoNewline
+        # UTF-8 without BOM. Out-File -Encoding UTF8 writes a BOM on Windows PowerShell 5.1,
+        # which breaks LDIF (RFC 2849 mandates no BOM) and many CSV consumers.
+        $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutFile)
+        $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+        [System.IO.File]::WriteAllText($resolvedPath, $output, $utf8NoBom)
         if ($TeeToStdOut) {
             Write-Output $output
         }
@@ -1102,13 +1141,15 @@ function Invoke-SearchAndOutput {
             $columns = $Attrs
         }
         else {
-            $colSet = [System.Collections.Generic.LinkedHashSet[string]]::new()
+            # Insertion-ordered de-duplication (no LinkedHashSet in .NET).
+            $seen = [System.Collections.Generic.HashSet[string]]::new()
+            $colList = [System.Collections.Generic.List[string]]::new()
             foreach ($entry in $transformedEntries) {
                 foreach ($key in $entry.Keys) {
-                    if ($key -ne 'dn') { [void]$colSet.Add($key) }
+                    if ($key -ne 'dn' -and $seen.Add($key)) { $colList.Add($key) }
                 }
             }
-            $columns = @($colSet)
+            $columns = $colList.ToArray()
         }
     }
 
@@ -1140,6 +1181,12 @@ function Invoke-SearchAndOutput {
 # ============================================================================
 # Main Execution
 # ============================================================================
+
+# Skip the main execution block when dot-sourced (e.g., from the test harness),
+# so callers can load helper functions without firing connection/search logic.
+if ($MyInvocation.InvocationName -eq '.') {
+    return
+}
 
 $exitCode = 0
 


### PR DESCRIPTION
## Summary

- **Unblocks `psldap.ps1` from loading at all.** The param block had case-insensitive duplicate aliases (`Z`/`z`, `A`/`a`, `S`/`s`) that PowerShell rejects with `The alias z is declared multiple times`. Removed the uppercase aliases — use `-useSSL`, `-typesOnly`, `-sortOrder` (full names) in place of ldapsearch's `-Z`, `-A`, `-S`.
- **Fixes `LinkedHashSet` runtime crash** on `CSV` / `tab-delimited` output without `-requestedAttribute`. `LinkedHashSet` is a Java type; .NET has no such class. Replaced with `HashSet[string]` + `List[string]` for ordered dedupe.
- **Fixes RFC 2849 LDIF compliance** — DNs needing it now emit `dn:: <base64>` instead of plain `dn: <raw>`. The previous edge-case test was a false positive (asserted only `dn: ` substring); replaced with a positive `dn::` test plus a negative-case test for printable-ASCII DNs.
- **Stable scrambling on PowerShell 7+.** `Invoke-ScrambleValue` used `String.GetHashCode()`, which is randomized per process on .NET Core / .NET 5+, breaking cross-run determinism. Swapped for an MD5-derived stable Int32 hash (non-cryptographic use, native to .NET, no module install).
- **UTF-8 without BOM** on file output. `Out-File -Encoding UTF8` writes a BOM on Windows PowerShell 5.1 — bad for LDIF (RFC forbids it) and many CSV consumers. Now uses `[System.IO.File]::WriteAllText` with `UTF8Encoding($false)`.
- **Test harness now dot-sources `psldap.ps1`** (with a guard on the main-execution block) instead of regex-extracting function definitions out of the source. The previous approach silently broke whenever section banners were reformatted.

## Docs

- Rewrote `README.md` to describe the current ldapsearch-style tool (the previous README still referenced the pre-uplift script that was removed in `957ef17`).
- Added `CHANGELOG.md` covering this release (0.2.1), the prior major uplift (0.2.0), and the original alpha (v0.1-alpha).

## No new dependencies

Still zero PowerShell modules required. The script uses only .NET BCL assemblies that ship with Windows (`System.DirectoryServices.Protocols`, `System.Net`, `System.Security.Cryptography.MD5`).

## Test plan

- [x] `.\run-tests.ps1 -Iterations 3` → **90 / 90** passing on each run
- [x] `Get-Help .\psldap.ps1` succeeds (verifies the alias parse error is gone)
- [ ] Smoke-test against a real LDAP server with `-outputFormat CSV` and no `-requestedAttribute` (exercises the formerly-crashing code path)
- [ ] Verify file output opens cleanly in a BOM-sensitive consumer (e.g. `openldap` `ldapadd` for LDIF round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)