### PR TITLE
Add regression tests for BOM-less file output and scramble determinism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,15 @@ clarification in the test harness.
   runs the same scramble there, and asserts the output matches the
   in-process result. Catches any regression to
   `String.GetHashCode()`-based hashing (which is randomized per
-  process on PowerShell 7+).
+  process on PowerShell 7+). Asserts `$LASTEXITCODE -eq 0` first so a
+  child-process failure surfaces with a clear message instead of a
+  confusing value mismatch.
+- Added a `Describe 'Get-StableStringHash'` block with four tests:
+  empty / `$null` return `0`, a pinned MD5-derived Int32 value for
+  `"hello"` (`0x2a40415d`), and a basic in-process determinism check.
+  The pinned value catches algorithm changes, endianness regressions,
+  and UTF-8 vs. UTF-16 encoding regressions without spawning a
+  subprocess.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to PSldap are documented here.
 
+## [0.2.2] - 2026-04-27
+
+Regression-coverage release. Adds tests targeting the two fixes from
+0.2.1 that previously had no dedicated test, plus a small documentation
+clarification in the test harness.
+
+### Tests
+
+- Added `Write-SearchOutput writes UTF-8 without BOM to output file` —
+  reads the first three bytes of the produced file and asserts they
+  are not `EF BB BF`. Catches any future regression that re-introduces
+  a BOM in file output.
+- Added `Invoke-ScrambleValue is deterministic across separate
+  PowerShell processes` — spawns a child `pwsh` via `-EncodedCommand`,
+  runs the same scramble there, and asserts the output matches the
+  in-process result. Catches any regression to
+  `String.GetHashCode()`-based hashing (which is randomized per
+  process on PowerShell 7+).
+
+### Documentation
+
+- Test harness now notes that dot-sourcing `psldap.ps1` imports its
+  `param()` block as variables in the test scope (e.g. `$hostname`,
+  `$port`, `$baseDN`, `$filter`, `$scope`), so future test authors
+  avoid accidental name collisions.
+
 ## [0.2.1] - 2026-04-25
 
 Hardening release: removes a latent script-load failure, fixes RFC

--- a/psldap.Tests.ps1
+++ b/psldap.Tests.ps1
@@ -145,6 +145,39 @@ Describe 'Test-LdapFilter' {
 }
 
 # ============================================================================
+# Get-StableStringHash Tests
+# ============================================================================
+Describe 'Get-StableStringHash' {
+    It 'Returns 0 for empty string' {
+        Assert-Equal 0 (Get-StableStringHash -Value '')
+    }
+
+    It 'Returns 0 for $null input' {
+        Assert-Equal 0 (Get-StableStringHash -Value $null)
+    }
+
+    It 'Pins MD5-derived Int32 output for "hello"' {
+        # MD5("hello") = 5d41402abc4b2a76b9719d911017c592
+        # First 4 bytes -> BitConverter::ToInt32 (little-endian) = 0x2a40415d.
+        # Pinning the exact value catches:
+        #   1. any change to the hashing algorithm (e.g. revert to GetHashCode)
+        #   2. accidental endianness changes
+        #   3. UTF-8 vs. UTF-16 encoding regressions
+        # Assumes little-endian (true on every platform PowerShell runs on).
+        Assert-Equal 0x2a40415d (Get-StableStringHash -Value 'hello')
+    }
+
+    It 'Produces the same output across repeated calls in this process' {
+        # Within a single process this is also true of GetHashCode(), so this
+        # test alone does not catch the cross-process regression — see the
+        # Regression Tests block for that. Kept here as a basic sanity check.
+        $a = Get-StableStringHash -Value 'TestValue'
+        $b = Get-StableStringHash -Value 'TestValue'
+        Assert-Equal $a $b
+    }
+}
+
+# ============================================================================
 # Invoke-ScrambleValue Tests
 # ============================================================================
 Describe 'Invoke-ScrambleValue' {
@@ -774,6 +807,9 @@ Describe 'Regression Tests' {
         $inner = ". '$scriptPath'; Invoke-ScrambleValue -Value 'TestValue123' -Seed 42"
         $encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($inner))
         $remoteResult = (& $pwshExe -NoProfile -NoLogo -EncodedCommand $encoded | Out-String).Trim()
+        # Surface child-process failures with a clear message instead of
+        # letting the value comparison fail with "Expected X, Got ''".
+        Assert-Equal 0 $LASTEXITCODE "Child PowerShell process exited non-zero. Output: $remoteResult"
 
         Assert-Equal $localResult $remoteResult "Scramble output differs across processes"
     }

--- a/psldap.Tests.ps1
+++ b/psldap.Tests.ps1
@@ -91,6 +91,11 @@ function Reset-TestResults {
 # ============================================================================
 # psldap.ps1 short-circuits its Main Execution block when dot-sourced
 # ($MyInvocation.InvocationName -eq '.'), so dot-sourcing only loads helpers.
+#
+# Side effect: dot-sourcing also imports psldap.ps1's param() block as
+# variables in this scope (e.g. $hostname, $port, $baseDN, $filter, $scope).
+# Avoid those names when introducing new test-scoped variables, or shadow
+# them deliberately inside an `It` block.
 
 . (Join-Path $PSScriptRoot 'psldap.ps1')
 
@@ -724,5 +729,52 @@ Describe 'Edge Cases' {
         Assert-Equal 76 $lines[0].Length
         # second line: space + 75 chars = 76
         if ($lines[1]) { Assert-Equal ' ' $lines[1][0] }
+    }
+}
+
+# ============================================================================
+# Regression Tests
+# ----------------------------------------------------------------------------
+# Tests targeting specific past regressions. Failures here indicate that a
+# previously-fixed bug has come back.
+# ============================================================================
+Describe 'Regression Tests' {
+    It 'Write-SearchOutput writes UTF-8 without BOM to output file' {
+        # Regression: Out-File -Encoding UTF8 emits a BOM on Windows
+        # PowerShell 5.1, which RFC 2849 forbids and many CSV consumers
+        # mis-parse. Fixed by routing through [IO.File]::WriteAllText
+        # with UTF8Encoding($false).
+        $outPath = Join-Path $env:TEMP 'psldap_test_bom.ldif'
+        try {
+            $entries = @([ordered]@{ dn = 'cn=test,dc=com'; cn = @('test') })
+            Write-SearchOutput -Entries $entries -Format 'LDIF' -WrapCol 76 -OutFile $outPath
+            $bytes = [System.IO.File]::ReadAllBytes($outPath)
+            Assert-True ($bytes.Length -ge 3) "Output file is too short to inspect for BOM"
+            $hasBom = ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF)
+            Assert-False $hasBom "Output file unexpectedly contains UTF-8 BOM"
+        }
+        finally {
+            if (Test-Path $outPath) { Remove-Item $outPath -Force }
+        }
+    }
+
+    It 'Invoke-ScrambleValue is deterministic across separate PowerShell processes' {
+        # Regression: String.GetHashCode() is randomized per process on
+        # .NET Core / PowerShell 7+, so scrambled output differed across
+        # runs. Fixed by hashing through Get-StableStringHash (MD5).
+        # This test spawns a fresh PowerShell process and verifies the
+        # same input produces the same output. If anyone reverts to
+        # GetHashCode(), this assertion will fail under PS 7+.
+        $pwshExe = (Get-Process -Id $PID).Path
+        Assert-NotNull $pwshExe "Could not resolve current PowerShell executable"
+
+        $scriptPath = Join-Path $PSScriptRoot 'psldap.ps1'
+        $localResult = Invoke-ScrambleValue -Value 'TestValue123' -Seed 42
+
+        $inner = ". '$scriptPath'; Invoke-ScrambleValue -Value 'TestValue123' -Seed 42"
+        $encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($inner))
+        $remoteResult = (& $pwshExe -NoProfile -NoLogo -EncodedCommand $encoded | Out-String).Trim()
+
+        Assert-Equal $localResult $remoteResult "Scramble output differs across processes"
     }
 }


### PR DESCRIPTION
## Summary

Adds dedicated regression coverage for the two fixes shipped in `0.2.1` that previously had no test, and clarifies a subtle behavior of the test harness.

### Tests added

- **`Write-SearchOutput writes UTF-8 without BOM to output file`** — writes a small LDIF entry to a temp file, reads the first three bytes, and asserts they are not `EF BB BF`. Catches any regression that re-introduces a BOM (e.g. reverting to `Out-File -Encoding UTF8` on Windows PowerShell 5.1).
- **`Invoke-ScrambleValue is deterministic across separate PowerShell processes`** — spawns a fresh `pwsh` via `-EncodedCommand`, dot-sources `psldap.ps1` there, runs the same scramble, and asserts the result matches the in-process call. Catches any regression to `String.GetHashCode()`-based hashing (which is randomized per process on PowerShell 7+).

### Documentation

- Comment block in `psldap.Tests.ps1` near the dot-source line now notes that dot-sourcing `psldap.ps1` imports its `param()` block as variables in test scope (e.g. `$hostname`, `$port`, `$baseDN`, `$filter`, `$scope`), so future test authors avoid accidental collisions.

### CHANGELOG

- Bumped to `0.2.2` with a `Tests` and `Documentation` section.

### Skipped from review

- The MD5-instance caching / `MD5.HashData()` optimization — left for a follow-up since it's an allocation-pressure tweak that needs benchmarking on a real workload, not a correctness fix.

## Test plan

- [ ] Run `.\run-tests.ps1` (PowerShell 7+ recommended) and confirm **92 / 92** passing across 3 iterations.
- [ ] Run on Windows PowerShell 5.1 to confirm the BOM test still passes (the fix and test both target 5.1's `Out-File` BOM behavior).
- [ ] Optional: temporarily revert `Get-StableStringHash` back to `$Value.GetHashCode()` and confirm the cross-process test fails on PowerShell 7+ — proves the test actually exercises the regression.

## Verification limitation

The sandbox these changes were authored in has no PowerShell runtime, so the suite was **not** executed locally. The new tests follow the same patterns as the existing 90 tests and use only the harness's existing assertion primitives (`Assert-Equal`, `Assert-True`, `Assert-False`, `Assert-NotNull`).

https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6)_