### PR TITLE
CI workflow + LinkedHashSet regression test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pwsh-windows:
+    name: PowerShell 7 (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show PowerShell version
+        shell: pwsh
+        run: $PSVersionTable
+
+      - name: Run test suite (3 iterations)
+        shell: pwsh
+        run: ./run-tests.ps1 -Iterations 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to PSldap are documented here.
 
+## [Unreleased]
+
+CI infrastructure and additional regression coverage. Builds on the
+test additions in #5.
+
+### Added
+
+- **GitHub Actions workflow** (`.github/workflows/tests.yml`). Runs
+  `run-tests.ps1 -Iterations 3` on `windows-latest` for every push to
+  `main` and every pull request targeting `main`. Gates merges on
+  test-suite green.
+- **`Source-Code Checks`** Describe block in `psldap.Tests.ps1` with a
+  test asserting the script does not reference `LinkedHashSet`. The
+  type doesn't exist in .NET; a regression to it crashed CSV / tab
+  output at runtime in a previous version. Static check, no LDAP
+  connection required.
+
+### Changed
+
+- `run-tests.ps1` now `exit 1`s when any test fails (sum of failures
+  across all iterations). Previously the script always exited 0, so
+  CI couldn't gate on test failures.
+
 ## [0.2.1] - 2026-04-25
 
 Hardening release: removes a latent script-load failure, fixes RFC

--- a/psldap.Tests.ps1
+++ b/psldap.Tests.ps1
@@ -681,6 +681,25 @@ Describe 'Read-FiltersFromFile - Filter Validation' {
     }
 }
 
+# ============================================================================
+# Source-Code Checks
+# ----------------------------------------------------------------------------
+# Tests that grep / parse psldap.ps1 itself to catch regressions that are
+# easier to spot statically than to reproduce behaviorally.
+# ============================================================================
+Describe 'Source-Code Checks' {
+    It 'psldap.ps1 does not reference [LinkedHashSet] (which does not exist in .NET)' {
+        # Regression: a previous version tried to instantiate
+        # [System.Collections.Generic.LinkedHashSet[string]] for ordered
+        # de-duplication. That type is Java; .NET has no equivalent and
+        # the script crashed at runtime on CSV / tab output without
+        # -requestedAttribute. Fixed by using HashSet[string] + List[string].
+        $scriptPath = Join-Path $PSScriptRoot 'psldap.ps1'
+        $content = Get-Content -Path $scriptPath -Raw
+        Assert-NotMatch $content 'LinkedHashSet'
+    }
+}
+
 Describe 'Edge Cases' {
     It 'Invoke-ScrambleValue preserves dash and exclamation in unicode string' {
         $result = Invoke-ScrambleValue -Value 'abcd-123!' -Seed 42

--- a/psldap.Tests.ps1
+++ b/psldap.Tests.ps1
@@ -694,9 +694,15 @@ Describe 'Source-Code Checks' {
         # de-duplication. That type is Java; .NET has no equivalent and
         # the script crashed at runtime on CSV / tab output without
         # -requestedAttribute. Fixed by using HashSet[string] + List[string].
+        #
+        # The pattern targets the .NET type-bracket syntax specifically
+        # ('[LinkedHashSet' or '[System.Collections.Generic.LinkedHashSet')
+        # rather than the bare word, so a comment that mentions the
+        # regression history (like the one in psldap.ps1) doesn't trigger
+        # a false positive.
         $scriptPath = Join-Path $PSScriptRoot 'psldap.ps1'
         $content = Get-Content -Path $scriptPath -Raw
-        Assert-NotMatch $content 'LinkedHashSet'
+        Assert-NotMatch $content '\[(System\.Collections\.Generic\.)?LinkedHashSet'
     }
 }
 

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -10,6 +10,8 @@ param(
     [int]$Iterations = 3
 )
 
+$totalFailed = 0
+
 for ($i = 1; $i -le $Iterations; $i++) {
     Write-Host "`n============================================" -ForegroundColor Cyan
     Write-Host "  Test Run $i of $Iterations" -ForegroundColor Cyan
@@ -33,5 +35,11 @@ for ($i = 1; $i -le $Iterations; $i++) {
         }
     }
 
+    $totalFailed += $summary.Failed
     Reset-TestResults
+}
+
+if ($totalFailed -gt 0) {
+    Write-Host "`nTotal failures across all runs: $totalFailed" -ForegroundColor Red
+    exit 1
 }


### PR DESCRIPTION
## Summary

Follow-up to #5. Wires up GitHub Actions to actually gate merges on the test suite, fixes `run-tests.ps1` to exit non-zero on failure (otherwise the gate is meaningless), and adds the one regression test from #5's review that wasn't included there.

## Changes

### CI

- New `.github/workflows/tests.yml` — runs `run-tests.ps1 -Iterations 3` on `windows-latest` under `pwsh` for every push to `main` and every PR targeting `main`.

### `run-tests.ps1`

- Now `exit 1`s when any test fails (sum of failures across all iterations). Previously the script always exited 0, which silently let CI gate on nothing. **Without this fix the new workflow would be a no-op.**

### `psldap.Tests.ps1`

- New `Describe 'Source-Code Checks'` block with one test asserting `psldap.ps1` does not reference `LinkedHashSet`. That type doesn't exist in .NET; a previous version tried to instantiate it and crashed CSV / tab output at runtime. Static check — no mocked LDAP connection required, runs in milliseconds.

### Skipped

- **Explicit alias-collision smoke test.** Redundant given the new CI gate: if `psldap.ps1`'s param block ever has duplicate aliases, dot-source at the top of `psldap.Tests.ps1` fails and the entire suite errors out, which CI will now catch.

## Branching / merge order

Branched from `main` (not from #5). #5's CHANGELOG entry (`0.2.2`) sits between this PR's `[Unreleased]` section and `[0.2.1]`.

- If #5 merges first: no conflict.
- If this PR merges first: maintainer slots #5's `0.2.2` entry under `[Unreleased]`.

The two PRs are otherwise independent.

## Test plan

- [ ] Merge or rebase locally and run `.\run-tests.ps1` — expect 91/91 passing (90 from main + 1 new). On the merged tree with #5, expect 95/95 (90 + 4 new in #5 + 1 new here).
- [ ] After merge, confirm the GitHub Actions workflow runs on the next push to `main` and reports green.
- [ ] Sanity check the gate works: temporarily inject a deliberate test failure on a branch and confirm CI fails the PR check.

## Verification limitation

The sandbox these changes were authored in has no PowerShell runtime, so the suite was **not** executed locally. The new test uses only existing harness primitives (`Assert-NotMatch`).

https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6)_