### PR TITLE
Add AD LDAP query toolkit (lightweight, native-only, CI-safe)

### DIFF
--- a/ad-ldap-query/Invoke-AdLdapQuery.ps1
+++ b/ad-ldap-query/Invoke-AdLdapQuery.ps1
@@ -1,0 +1,216 @@
+<#
+.SYNOPSIS
+    Lightweight, native-only AD LDAP query script. No PowerShell modules
+    required, no RSAT dependency.
+
+.DESCRIPTION
+    Defines Invoke-AdLdapQuery, a function that runs a single LDAP search
+    against the current user's domain using only .NET BCL classes that
+    ship with every Windows install:
+
+      - System.DirectoryServices.ActiveDirectory.Domain (domain discovery)
+      - System.DirectoryServices.DirectoryEntry        (LDAP bind)
+      - System.DirectoryServices.DirectorySearcher     (paged search)
+
+    Authentication uses Kerberos / GSSAPI implicitly via the calling
+    user's logon token. There is no plaintext password handling.
+
+    The script can be either dot-sourced (so the test harness can call
+    the function in-process) or invoked directly with -Filter for a
+    one-shot query.
+
+.PARAMETER Filter
+    Required. The LDAP filter, e.g. "(objectClass=user)". Validated for
+    parenthesis balance before any AD I/O happens, so malformed filters
+    fail fast and locally without a server round-trip.
+
+.PARAMETER Properties
+    Optional. Attributes to load. Defaults to a small set of the most
+    common user/object attributes:
+      samAccountName, displayName, mail, distinguishedName,
+      objectClass, userPrincipalName
+
+.PARAMETER MaxResults
+    Optional. Server-side size limit. Defaults to 100. Capped at 1000
+    per page (DirectorySearcher PageSize).
+
+.EXAMPLE
+    .\Invoke-AdLdapQuery.ps1 -Filter '(objectClass=user)' -MaxResults 5
+
+.EXAMPLE
+    . .\Invoke-AdLdapQuery.ps1
+    Invoke-AdLdapQuery -Filter '(samAccountName=jdoe)' -Properties mail,displayName
+
+.NOTES
+    No [CmdletBinding()] is used; the script-level param() block is
+    intentionally non-mandatory so dot-sourcing for tests does not
+    prompt for input.
+
+    Why DirectorySearcher instead of the ActiveDirectory module?
+      - The AD module ships with RSAT and is not installed on locked-
+        down or non-admin workstations.
+      - DirectorySearcher / DirectoryEntry are part of the .NET BCL on
+        every Windows PowerShell install.
+      - No external module install, no admin rights, no DSC bootstrap.
+#>
+
+param(
+    [string]$Filter,
+    [string[]]$Properties,
+    [int]$MaxResults = 100
+)
+
+# ============================================================================
+# Helper: structural LDAP-filter check (no AD round-trip).
+# Catches the most common malformed filters (unbalanced parens, empty input)
+# locally so the function fails fast without binding to AD.
+# ============================================================================
+function Test-AdLdapFilterShape {
+    param([string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $false }
+    if ($Value[0] -ne '(' -or $Value[$Value.Length - 1] -ne ')') { return $false }
+
+    $depth = 0
+    foreach ($ch in $Value.ToCharArray()) {
+        if ($ch -eq '(') { $depth++ }
+        elseif ($ch -eq ')') { $depth-- }
+        if ($depth -lt 0) { return $false }
+    }
+    return ($depth -eq 0)
+}
+
+# ============================================================================
+# Helper: discover the current AD domain via .NET (no RSAT, no modules).
+# Returns the FQDN string, or throws with a clear message.
+# ============================================================================
+function Get-AdLdapCurrentDomain {
+    try {
+        $d = [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
+        return $d.Name
+    }
+    catch {
+        throw "Could not discover the current Active Directory domain. " +
+              "Is this machine domain-joined and reachable? " +
+              "Inner: $($_.Exception.Message)"
+    }
+}
+
+# ============================================================================
+# The main exported function.
+# ============================================================================
+function Invoke-AdLdapQuery {
+    param(
+        [string]$Filter,
+        [string[]]$Properties = @(
+            'samAccountName',
+            'displayName',
+            'mail',
+            'distinguishedName',
+            'objectClass',
+            'userPrincipalName'
+        ),
+        [int]$MaxResults = 100
+    )
+
+    # --- Local validation (no AD I/O yet) ---
+    if (-not (Test-AdLdapFilterShape -Value $Filter)) {
+        throw "Invalid LDAP filter: '$Filter'. " +
+              "Filter must be non-empty, start with '(', end with ')', " +
+              "and have balanced parentheses."
+    }
+
+    if ($MaxResults -lt 1) {
+        throw "MaxResults must be a positive integer (got $MaxResults)."
+    }
+
+    # --- Domain discovery ---
+    $domainName = Get-AdLdapCurrentDomain
+    $rootPath = "LDAP://$domainName"
+
+    # --- Bind ---
+    # No credentials passed = bind as the current logged-on user via Kerberos.
+    # No plaintext password ever leaves this process.
+    $root = $null
+    $searcher = $null
+    $results = $null
+    try {
+        try {
+            $root = New-Object System.DirectoryServices.DirectoryEntry $rootPath
+            # Force-touch a property so a bind error (Kerberos failure, etc.)
+            # surfaces here rather than later inside FindAll().
+            $null = $root.Name
+        }
+        catch {
+            throw "Failed to bind to '$rootPath' as the current user. " +
+                  "Possible Kerberos / domain reachability issue. " +
+                  "Inner: $($_.Exception.Message)"
+        }
+
+        # --- Search ---
+        try {
+            $searcher = New-Object System.DirectoryServices.DirectorySearcher $root
+            $searcher.Filter = $Filter
+            $searcher.SizeLimit = $MaxResults
+            # PageSize > 0 enables paged results; cap at 1000 per RFC convention.
+            $pageSize = [Math]::Min(1000, [Math]::Max(1, $MaxResults))
+            $searcher.PageSize = $pageSize
+            $searcher.SearchScope = [System.DirectoryServices.SearchScope]::Subtree
+
+            foreach ($prop in $Properties) {
+                if (-not [string]::IsNullOrWhiteSpace($prop)) {
+                    [void]$searcher.PropertiesToLoad.Add($prop)
+                }
+            }
+
+            $results = $searcher.FindAll()
+        }
+        catch [System.Runtime.InteropServices.COMException] {
+            # COM 0x80072020 / 0x8007203E etc. usually means a server-side
+            # filter parse error or operations error.
+            throw "LDAP search failed (server rejected the request). " +
+                  "Filter: '$Filter'. Inner: $($_.Exception.Message)"
+        }
+        catch {
+            throw "LDAP search failed. Filter: '$Filter'. Inner: $($_.Exception.Message)"
+        }
+
+        # --- Project results into PSCustomObjects ---
+        foreach ($result in $results) {
+            $obj = [ordered]@{}
+            foreach ($prop in $Properties) {
+                $vals = $result.Properties[$prop]
+                if ($vals -and $vals.Count -gt 0) {
+                    if ($vals.Count -eq 1) {
+                        $obj[$prop] = $vals[0]
+                    }
+                    else {
+                        $obj[$prop] = @($vals)
+                    }
+                }
+                else {
+                    $obj[$prop] = $null
+                }
+            }
+            [PSCustomObject]$obj
+        }
+    }
+    finally {
+        if ($results)  { try { $results.Dispose() }  catch {} }
+        if ($searcher) { try { $searcher.Dispose() } catch {} }
+        if ($root)     { try { $root.Dispose() }     catch {} }
+    }
+}
+
+# ============================================================================
+# Standalone-invocation entry point.
+# When the file is dot-sourced ($MyInvocation.InvocationName -eq '.'), do
+# nothing — let the caller use Invoke-AdLdapQuery directly.
+# When invoked as a script with -Filter, forward to the function.
+# ============================================================================
+if ($MyInvocation.InvocationName -ne '.' -and $Filter) {
+    $callArgs = @{ Filter = $Filter }
+    if ($PSBoundParameters.ContainsKey('Properties')) { $callArgs.Properties = $Properties }
+    if ($PSBoundParameters.ContainsKey('MaxResults')) { $callArgs.MaxResults = $MaxResults }
+    Invoke-AdLdapQuery @callArgs
+}

--- a/ad-ldap-query/README.md
+++ b/ad-ldap-query/README.md
@@ -1,0 +1,242 @@
+# AD LDAP Query Toolkit (lightweight, native-only)
+
+A small, dependency-free pair of PowerShell scripts for querying
+Active Directory over LDAP from a generic Windows workstation. No
+PowerShell modules are required, no RSAT, no admin rights — just
+`.NET BCL` classes that ship with every Windows install.
+
+This is a sibling to the larger `psldap.ps1` at the repo root. Use
+this toolkit when you want a minimal "starter kit" that is easy to
+audit, drop into a CI pipeline, or hand to a junior engineer.
+
+## Files
+
+| File                          | Purpose                                                        |
+|-------------------------------|----------------------------------------------------------------|
+| `Invoke-AdLdapQuery.ps1`      | The script under test. Defines the `Invoke-AdLdapQuery` fn.    |
+| `Test-AdLdapQueryHarness.ps1` | Native-only test harness with offline + live test segregation. |
+
+## Why no modules and why `DirectorySearcher`
+
+- The `ActiveDirectory` PowerShell module is part of RSAT. It is
+  **not installed by default** on Windows client editions and is
+  often blocked on locked-down workstations. Scripts that depend on
+  it are unusable in those environments.
+- `System.DirectoryServices.DirectorySearcher` and
+  `System.DirectoryServices.DirectoryEntry` are part of the .NET BCL
+  on every Windows PowerShell 5.x install. No install, no admin
+  required.
+- Authentication is implicit Kerberos / GSSAPI via the calling user's
+  logon token. **No plaintext credentials** are passed at any point.
+
+## Quick start
+
+### Run the query script directly
+
+```powershell
+# One-shot query (script auto-discovers the current domain)
+.\Invoke-AdLdapQuery.ps1 -Filter '(objectClass=user)' -MaxResults 5
+
+# Subset of attributes
+.\Invoke-AdLdapQuery.ps1 -Filter '(samAccountName=jdoe)' -Properties mail,displayName
+
+# Or dot-source and call the function
+. .\Invoke-AdLdapQuery.ps1
+Invoke-AdLdapQuery -Filter '(&(objectClass=user)(department=Finance))' -MaxResults 50
+```
+
+### Run the test harness
+
+```powershell
+# Default: offline tests only (works anywhere, no AD required)
+.\Test-AdLdapQueryHarness.ps1
+
+# Full suite on a domain-joined workstation
+$env:RUN_LIVE_AD_TESTS = '1'
+.\Test-AdLdapQueryHarness.ps1
+
+# Verbose per-test logging
+.\Test-AdLdapQueryHarness.ps1 -Detailed
+
+# JSON output for downstream tooling
+.\Test-AdLdapQueryHarness.ps1 -Json | Out-File results.json -Encoding utf8
+```
+
+### Exit codes
+
+| Code | Meaning                                |
+|------|----------------------------------------|
+| 0    | All executed tests passed (skips OK)   |
+| 1    | At least one test failed               |
+
+## Test segmentation
+
+| Category   | When it runs                                                                                  | Notes                                                    |
+|------------|-----------------------------------------------------------------------------------------------|----------------------------------------------------------|
+| Offline    | Always.                                                                                       | Safe for non-admin users, locked-down workstations, CI.  |
+| Live AD    | Only when `RUN_LIVE_AD_TESTS=1`.                                                              | Requires domain-join. Issues read-only LDAP queries.     |
+
+The harness fails loudly if `RUN_LIVE_AD_TESTS=1` is set but AD is
+unreachable — that combination is operator misconfiguration, not a
+routine condition.
+
+### Offline tests
+
+Run without any AD connectivity. Cover:
+
+- Script file presence
+- `System.DirectoryServices` types loadable
+- Script dot-sources cleanly (parser + param-block validity)
+- `Invoke-AdLdapQuery` function exported after dot-source
+- Empty / whitespace filter rejected before any AD I/O
+- Malformed filter (unbalanced parens) rejected locally
+- Negative `MaxResults` rejected
+
+### Live AD tests
+
+Run only with `RUN_LIVE_AD_TESTS=1` on a domain-joined machine.
+Read-only and safe for any user with normal Domain Users
+permissions. Cover:
+
+- AD domain discovery via
+  `[System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()`
+- Basic user query (`(objectClass=user)`, MaxResults=5) returns >= 1 result
+- Property selection returns exactly the requested attributes
+- Nonexistent-account query returns an empty set without throwing
+- Returned objects expose `distinguishedName`
+
+## Environment variables
+
+| Variable               | Meaning                                                                   |
+|------------------------|---------------------------------------------------------------------------|
+| `RUN_LIVE_AD_TESTS`    | `1` to enable live AD tests. Anything else leaves them skipped.           |
+| `LIVE_AD_TEST_RETRIES` | Integer N. Up to N additional retry attempts per live test on transient failures (server unavailable, RPC timeout, 0x80072030, etc.). Default `0`. |
+
+## GitHub Actions
+
+Two example workflows. Neither is wired up as a live workflow file in
+this repo — copy whichever fits your environment into
+`.github/workflows/`.
+
+### A. GitHub-hosted runner (offline only)
+
+Runs on `windows-latest`. GitHub-hosted runners are **not** domain-
+joined and cannot reach corporate AD. The harness skips live tests
+and gates only on offline correctness. Suitable for every PR.
+
+```yaml
+name: ad-ldap-toolkit-offline
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ad-ldap-query/**'
+  push:
+    branches: [main]
+    paths:
+      - 'ad-ldap-query/**'
+
+jobs:
+  offline:
+    name: Offline tests (Windows-hosted)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run harness (offline only)
+        shell: pwsh
+        working-directory: ad-ldap-query
+        # RUN_LIVE_AD_TESTS is not set, so live tests SKIP and only
+        # offline correctness is gated.
+        run: ./Test-AdLdapQueryHarness.ps1
+```
+
+### B. Self-hosted runner (full suite, domain-joined)
+
+This workflow only works on a **self-hosted runner that is joined to
+your corporate domain**. The runner's service account must be able to
+bind to LDAP and read directory objects (any account in `Domain
+Users` is enough for the read-only tests). GitHub-hosted runners
+cannot run this workflow.
+
+```yaml
+name: ad-ldap-toolkit-full
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ad-ldap-query/**'
+
+jobs:
+  full:
+    name: Offline + live AD tests (self-hosted)
+    # Replace [windows, ad-joined] with whatever labels your runner exposes.
+    runs-on: [self-hosted, windows, ad-joined]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run harness (full)
+        shell: pwsh
+        working-directory: ad-ldap-query
+        env:
+          RUN_LIVE_AD_TESTS: '1'
+          LIVE_AD_TEST_RETRIES: '2'
+        run: ./Test-AdLdapQueryHarness.ps1 -Detailed
+```
+
+If your security team requires non-default credentials for the LDAP
+bind, do **not** hardcode them in the workflow. Inject them through
+GitHub Secrets and have the harness read environment variables — but
+the default Kerberos path (current logon token, no creds) is the
+preferred design and what this toolkit ships with.
+
+## Validating locally
+
+```powershell
+# 1. Confirm the harness runs offline (this is what GitHub-hosted CI does)
+$env:RUN_LIVE_AD_TESTS = $null
+.\Test-AdLdapQueryHarness.ps1
+# Expect: PASS / SKIP only, exit 0
+
+# 2. Confirm the gate works (live tests skip without the env var)
+.\Test-AdLdapQueryHarness.ps1 | Select-String 'Live AD tests'
+# Expect: "Live AD tests : disabled..."
+
+# 3. Confirm domain discovery works (independent of the harness)
+[System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain().Name
+
+# 4. Run the full suite on a domain-joined workstation
+$env:RUN_LIVE_AD_TESTS = '1'
+.\Test-AdLdapQueryHarness.ps1 -Detailed
+# Expect: every PASS or SKIP, exit 0
+```
+
+## Common failure modes (and how this design prevents them)
+
+| Failure                                                    | Cause                                                                | This design                                                                                              |
+|------------------------------------------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| CI fails on GitHub-hosted runners with "domain not found"  | Stock GitHub runners are not domain-joined.                          | Live tests skip by default; CI never tries to talk to AD unless the operator opts in.                    |
+| Malformed filter sends a wasted request to the DC          | DirectorySearcher accepts any string and rejects at FindAll() time.  | `Invoke-AdLdapQuery` runs a parens-balance check first. Bad filters fail locally, no round-trip.         |
+| Non-admin user can't load the AD module                    | `Import-Module ActiveDirectory` requires RSAT.                       | This toolkit never imports modules. `DirectorySearcher` is in the .NET BCL on every Windows install.     |
+| Plaintext password leaks in logs                           | Passing `-Credential` with a plain string.                           | No credential parameter exists. Auth is implicit Kerberos via the current logon token.                   |
+| Test passes locally, fails in CI because of timing         | Transient LDAP / RPC blips on first connection.                      | `LIVE_AD_TEST_RETRIES` env var provides bounded retries with exponential-ish back-off on transient errors. |
+| Dot-source for tests accidentally fires the script body    | Top-level statements run on every dot-source.                        | The standalone-invocation block at the bottom guards on `$MyInvocation.InvocationName -ne '.'` and `$Filter`. |
+| Test author can't tell offline vs live failures            | Mixed output, opaque failure reasons.                                | Each result row carries a `Status` (`PASS` / `FAIL` / `SKIP`) and a `Message`; `-Json` gives a structured payload. |
+
+## Security notes
+
+- **No plaintext credentials.** The script never accepts a password
+  parameter; auth is the calling user's Kerberos token via
+  `DirectoryEntry`'s default constructor.
+- **Read-only operations.** Every LDAP call is a `DirectorySearcher`
+  search. There are no add / modify / delete code paths.
+- **No external module install.** The script uses only types from
+  `System.DirectoryServices*` namespaces that ship in the .NET BCL.
+  A locked-down workstation that can run any PowerShell at all can
+  run this.
+- **Bounded blast radius.** `MaxResults` defaults to 100 and is
+  enforced server-side via `SizeLimit`. A typo cannot accidentally
+  page through a million-object directory.

--- a/ad-ldap-query/Test-AdLdapQueryHarness.ps1
+++ b/ad-ldap-query/Test-AdLdapQueryHarness.ps1
@@ -1,0 +1,336 @@
+<#
+.SYNOPSIS
+    Lightweight, native-only test harness for Invoke-AdLdapQuery.ps1.
+
+.DESCRIPTION
+    Two test categories with explicit gating:
+
+    1. Offline tests — always run. No AD connectivity required. Cover
+       script load, function existence, and parameter validation that
+       the function performs locally before any LDAP I/O.
+
+    2. Live AD tests — gated behind RUN_LIVE_AD_TESTS=1. Run only on a
+       domain-joined machine (or a self-hosted CI runner). Issue safe,
+       read-only LDAP queries against the current user's domain.
+
+    Default behaviour (env var unset): only offline tests run. The
+    harness can therefore execute unmodified on a stock GitHub-hosted
+    windows-latest runner — CI passes on offline correctness, AD
+    connectivity is not required.
+
+    On a domain-joined machine, set RUN_LIVE_AD_TESTS=1 to run the full
+    suite. If the env var is set but the machine cannot reach AD, the
+    live tests fail loudly (this is operator misconfiguration, not a
+    routine condition).
+
+.PARAMETER Json
+    Emit machine-readable JSON to stdout instead of the default
+    formatted table. Useful for piping into a result aggregator.
+
+.PARAMETER Detailed
+    Verbose per-test logging (entry, retry attempts, timings).
+
+.EXAMPLE
+    # Stock CI (offline only)
+    .\Test-AdLdapQueryHarness.ps1
+
+.EXAMPLE
+    # Full run on a domain-joined workstation
+    $env:RUN_LIVE_AD_TESTS = '1'
+    .\Test-AdLdapQueryHarness.ps1
+
+.EXAMPLE
+    # JSON output for downstream tooling
+    .\Test-AdLdapQueryHarness.ps1 -Json | Out-File results.json -Encoding utf8
+
+.NOTES
+    PS 5.x compatible. No CmdletBinding, no Pester, no external
+    modules. Exit code 0 = all pass (or skip), 1 = at least one FAIL.
+
+    Optional env vars:
+      RUN_LIVE_AD_TESTS    '1' to enable live AD tests (default: off)
+      LIVE_AD_TEST_RETRIES integer N → up to N retries on transient
+                           LDAP failures (default: 0, no retries)
+#>
+
+param(
+    [switch]$Json,
+    [switch]$Detailed
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ============================================================================
+# Result collector
+# ============================================================================
+$script:Results = New-Object System.Collections.Generic.List[object]
+
+function Add-Result {
+    param(
+        [string]$Name,
+        [ValidateSet('PASS','FAIL','SKIP')]
+        [string]$Status,
+        [string]$Message = '',
+        [int]$DurationMs = 0
+    )
+    $row = [PSCustomObject]@{
+        Test     = $Name
+        Status   = $Status
+        Duration = $DurationMs
+        Message  = $Message
+    }
+    $script:Results.Add($row)
+    if (-not $Json -and $Detailed) {
+        $color = switch ($Status) { 'PASS' { 'Green' }; 'FAIL' { 'Red' }; default { 'Yellow' } }
+        Write-Host ("    [{0,-4}] {1} ({2} ms) {3}" -f $Status, $Name, $DurationMs, $Message) -ForegroundColor $color
+    }
+}
+
+# ============================================================================
+# Pre-flight environment detection
+# ============================================================================
+$script:LiveAdEnabled        = ($env:RUN_LIVE_AD_TESTS -eq '1')
+$script:DomainAvailable      = $false
+$script:DomainName           = $null
+$script:DomainDiscoveryError = $null
+
+try {
+    $d = [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
+    $script:DomainAvailable = $true
+    $script:DomainName = $d.Name
+}
+catch {
+    $script:DomainDiscoveryError = $_.Exception.Message
+}
+
+# ============================================================================
+# Test wrappers
+# ============================================================================
+function Run-OfflineTest {
+    <#
+    .SYNOPSIS
+        Run a test that does not require AD. Always executes.
+    #>
+    param(
+        [string]$Name,
+        [scriptblock]$Body
+    )
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        & $Body
+        $sw.Stop()
+        Add-Result -Name $Name -Status 'PASS' -DurationMs ([int]$sw.ElapsedMilliseconds)
+    }
+    catch {
+        $sw.Stop()
+        Add-Result -Name $Name -Status 'FAIL' -DurationMs ([int]$sw.ElapsedMilliseconds) `
+            -Message ("Exception: " + $_.Exception.Message)
+    }
+}
+
+function Run-LiveTest {
+    <#
+    .SYNOPSIS
+        Run a test that requires AD. Behaviour:
+          - RUN_LIVE_AD_TESTS != 1                : SKIP
+          - RUN_LIVE_AD_TESTS = 1, AD unreachable : FAIL (misconfig)
+          - RUN_LIVE_AD_TESTS = 1, AD reachable   : execute (with retries
+                                                    if LIVE_AD_TEST_RETRIES set)
+    #>
+    param(
+        [string]$Name,
+        [scriptblock]$Body
+    )
+    if (-not $script:LiveAdEnabled) {
+        Add-Result -Name $Name -Status 'SKIP' `
+            -Message 'Live AD tests disabled (set RUN_LIVE_AD_TESTS=1 to enable)'
+        return
+    }
+    if (-not $script:DomainAvailable) {
+        Add-Result -Name $Name -Status 'FAIL' `
+            -Message ("RUN_LIVE_AD_TESTS=1 but AD is unreachable: " + $script:DomainDiscoveryError)
+        return
+    }
+
+    # Retry budget for transient failures
+    $maxAttempts = 1
+    if ($env:LIVE_AD_TEST_RETRIES) {
+        $parsed = 0
+        if ([int]::TryParse($env:LIVE_AD_TEST_RETRIES, [ref]$parsed)) {
+            $maxAttempts = [Math]::Max(1, $parsed + 1)
+        }
+    }
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $attempt = 0
+    while ($true) {
+        $attempt++
+        try {
+            & $Body
+            $sw.Stop()
+            $msg = if ($attempt -gt 1) { "Succeeded on attempt $attempt" } else { '' }
+            Add-Result -Name $Name -Status 'PASS' -DurationMs ([int]$sw.ElapsedMilliseconds) -Message $msg
+            return
+        }
+        catch {
+            $msg = $_.Exception.Message
+            $isTransient = $msg -match 'server is not operational|server unavailable|0x80072030|connection.*reset|timed?\s*out|RPC server is unavailable'
+            if ($isTransient -and $attempt -lt $maxAttempts) {
+                if ($Detailed) {
+                    Write-Host ("    [retry] {0} attempt {1}: {2}" -f $Name, $attempt, $msg) -ForegroundColor DarkYellow
+                }
+                Start-Sleep -Seconds 2
+                continue
+            }
+            $sw.Stop()
+            Add-Result -Name $Name -Status 'FAIL' -DurationMs ([int]$sw.ElapsedMilliseconds) `
+                -Message ("Exception: " + $msg)
+            return
+        }
+    }
+}
+
+function Assert-True {
+    param($Value, [string]$Message = '')
+    if (-not $Value) { throw "Expected truthy. $Message" }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message = '')
+    if ($Expected -ne $Actual) {
+        throw ("Expected '{0}', got '{1}'. {2}" -f $Expected, $Actual, $Message)
+    }
+}
+
+# ============================================================================
+# Pre-flight (informational)
+# ============================================================================
+$preflightStatus  = if ($script:DomainAvailable) { 'PASS' } else { 'SKIP' }
+$preflightMessage = if ($script:DomainAvailable) { $script:DomainName } `
+                    else { "Not reachable: $($script:DomainDiscoveryError)" }
+Add-Result -Name 'AD domain discovery (pre-flight)' -Status $preflightStatus -Message $preflightMessage
+
+# ============================================================================
+# Offline tests
+# ============================================================================
+$scriptPath = Join-Path $PSScriptRoot 'Invoke-AdLdapQuery.ps1'
+
+Run-OfflineTest 'Script file exists' {
+    Assert-True (Test-Path $scriptPath -PathType Leaf) "Expected $scriptPath"
+}
+
+Run-OfflineTest 'Native DirectoryServices types are loadable' {
+    [void][System.DirectoryServices.DirectoryEntry]
+    [void][System.DirectoryServices.DirectorySearcher]
+    [void][System.DirectoryServices.ActiveDirectory.Domain]
+}
+
+# Dot-source once in the harness scope so subsequent tests can call the
+# function directly. If dot-source fails, the per-test "function exists"
+# check below will fail with a clear message.
+$dotSourceOk = $false
+$dotSourceErr = $null
+try {
+    . $scriptPath
+    $dotSourceOk = $true
+}
+catch {
+    $dotSourceErr = $_.Exception.Message
+}
+
+Run-OfflineTest 'Script dot-sources cleanly' {
+    Assert-True $dotSourceOk "Dot-source failed: $dotSourceErr"
+}
+
+Run-OfflineTest 'Function Invoke-AdLdapQuery is defined after dot-source' {
+    $cmd = Get-Command Invoke-AdLdapQuery -ErrorAction SilentlyContinue
+    Assert-True ($null -ne $cmd) "Invoke-AdLdapQuery not defined"
+}
+
+Run-OfflineTest 'Empty filter is rejected' {
+    $threw = $false
+    try { Invoke-AdLdapQuery -Filter '' } catch { $threw = $true }
+    Assert-True $threw "Empty filter should throw before any AD I/O"
+}
+
+Run-OfflineTest 'Whitespace-only filter is rejected' {
+    $threw = $false
+    try { Invoke-AdLdapQuery -Filter '   ' } catch { $threw = $true }
+    Assert-True $threw "Whitespace-only filter should throw"
+}
+
+Run-OfflineTest 'Malformed filter (unbalanced parens) is rejected before AD I/O' {
+    $threw = $false
+    $errMsg = ''
+    try { Invoke-AdLdapQuery -Filter '(objectClass=user' } catch { $threw = $true; $errMsg = $_.Exception.Message }
+    Assert-True $threw "Unbalanced filter should throw locally"
+    # The error must mention the local validation, not an LDAP server error,
+    # so we know we did not attempt a round-trip.
+    Assert-True ($errMsg -match 'Invalid LDAP filter') "Expected local validation message, got: $errMsg"
+}
+
+Run-OfflineTest 'Negative MaxResults is rejected' {
+    $threw = $false
+    try { Invoke-AdLdapQuery -Filter '(objectClass=user)' -MaxResults -1 } catch { $threw = $true }
+    Assert-True $threw "Negative MaxResults should throw"
+}
+
+# ============================================================================
+# Live AD tests (gated)
+# ============================================================================
+Run-LiveTest 'Basic user query returns at least one result' {
+    $r = @(Invoke-AdLdapQuery -Filter '(objectClass=user)' -MaxResults 5)
+    Assert-True ($r.Count -gt 0) "Expected >= 1 result, got $($r.Count)"
+}
+
+Run-LiveTest 'Selected properties returns only the requested attributes' {
+    $r = @(Invoke-AdLdapQuery -Filter '(objectClass=user)' -Properties @('samAccountName') -MaxResults 1)
+    Assert-True ($r.Count -ge 1) "Expected >= 1 result"
+    $first = $r[0]
+    $names = @($first.PSObject.Properties.Name)
+    Assert-Equal 1 $names.Count "Expected 1 property, got $($names.Count): $($names -join ',')"
+    Assert-Equal 'samAccountName' $names[0] "Property name should be samAccountName"
+}
+
+Run-LiveTest 'No-results query returns an empty set without throwing' {
+    $needle = '__definitely_does_not_exist_q9z__'
+    $r = @(Invoke-AdLdapQuery -Filter "(samAccountName=$needle)" -MaxResults 5)
+    Assert-Equal 0 $r.Count "Expected 0 results for nonexistent samAccountName"
+}
+
+Run-LiveTest 'Returned objects expose distinguishedName' {
+    $r = @(Invoke-AdLdapQuery -Filter '(objectClass=user)' -Properties @('distinguishedName') -MaxResults 1)
+    Assert-True ($r.Count -ge 1) "Expected >= 1 result"
+    Assert-True (-not [string]::IsNullOrWhiteSpace($r[0].distinguishedName)) "distinguishedName should be populated"
+}
+
+# ============================================================================
+# Output
+# ============================================================================
+$resultsArr = @($script:Results)
+$passed  = @($resultsArr | Where-Object { $_.Status -eq 'PASS' }).Count
+$failed  = @($resultsArr | Where-Object { $_.Status -eq 'FAIL' }).Count
+$skipped = @($resultsArr | Where-Object { $_.Status -eq 'SKIP' }).Count
+
+if ($Json) {
+    [PSCustomObject]@{
+        domain        = $script:DomainName
+        liveTestsMode = if ($script:LiveAdEnabled) { 'enabled' } else { 'disabled' }
+        passed        = $passed
+        failed        = $failed
+        skipped       = $skipped
+        results       = $resultsArr
+    } | ConvertTo-Json -Depth 5
+}
+else {
+    $displayDomain = if ($script:DomainName) { $script:DomainName } else { '<none>' }
+    $displayLive   = if ($script:LiveAdEnabled) { 'ENABLED' } else { 'disabled (set RUN_LIVE_AD_TESTS=1)' }
+    Write-Host ""
+    Write-Host "Domain        : $displayDomain"
+    Write-Host "Live AD tests : $displayLive"
+    Write-Host ""
+    $resultsArr | Format-Table -AutoSize Test, Status, Duration, Message | Out-String | Write-Host
+    Write-Host ("Passed: {0}   Failed: {1}   Skipped: {2}" -f $passed, $failed, $skipped)
+}
+
+if ($failed -gt 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
## Summary

A new sibling toolkit alongside `psldap.ps1`, aimed at a different audience: a minimal, dependency-free "starter kit" for querying AD over LDAP from locked-down, non-admin Windows workstations — and one that runs cleanly in CI without depending on AD connectivity that GitHub-hosted runners can't provide.

All artifacts live under `ad-ldap-query/`. Nothing in this PR touches the existing `psldap.ps1` / `psldap.Tests.ps1` / `run-tests.ps1` / `CHANGELOG.md`.

## Design

### Native-only, no modules

Both scripts use only types from `System.DirectoryServices.*` (`DirectoryEntry`, `DirectorySearcher`, `ActiveDirectory.Domain`) — part of the .NET BCL on every Windows install. No `Import-Module ActiveDirectory`, no RSAT, no admin rights. Auth is implicit Kerberos via the current logon token; the script never accepts a password parameter.

### Two-tier test gating

The harness segregates tests:

| Category   | When it runs                                 |
|------------|----------------------------------------------|
| Offline    | Always. No AD required.                      |
| Live AD    | Only when `RUN_LIVE_AD_TESTS=1`.             |

Result: the harness can run unmodified on stock `windows-latest` GitHub-hosted runners and gate offline correctness; on a self-hosted domain-joined runner you set the env var and the full suite runs. `RUN_LIVE_AD_TESTS=1` + AD unreachable is treated as FAIL (operator misconfig), not SKIP.

### Production hardening from the spec

- `Run-OfflineTest` / `Run-LiveTest` wrappers; uniform `PASS` / `FAIL` / `SKIP` rows with timing.
- Bounded retry on transient LDAP failures via `LIVE_AD_TEST_RETRIES` env var (default 0).
- `-Json` output for downstream tooling; `-Detailed` for verbose logging.
- `Invoke-AdLdapQuery` does a local parens-balance check on the filter before any AD I/O, so malformed filters fail fast without a server round-trip — and the offline test for that case requires no domain.
- Exit 0 on all-pass-or-skip, 1 on any FAIL.
- PS 5.x compatible. No `[CmdletBinding()]` (per spec).

## Files

| File | Lines | Purpose |
|------|-------|---------|
| `ad-ldap-query/Invoke-AdLdapQuery.ps1` | 216 | Script + `Invoke-AdLdapQuery` function |
| `ad-ldap-query/Test-AdLdapQueryHarness.ps1` | 336 | Harness with offline/live segregation, retry, JSON |
| `ad-ldap-query/README.md` | 242 | Design rationale, quick-start, both workflows as YAML, validation, failure-mode table |

## Workflows shown as YAML, not live

Two GitHub Actions workflows are documented as code blocks in `ad-ldap-query/README.md`:

- **A. GitHub-hosted runner (offline only)** — runs on every PR, gates offline correctness, never tries to reach AD.
- **B. Self-hosted runner (full suite, domain-joined)** — runs the full suite, requires a self-hosted runner with appropriate runner labels.

Neither is wired up as a live `.github/workflows/` file — per the conversation's earlier decision, a live offline workflow would duplicate PR #6's coverage of the existing `psldap` suite, and a live self-hosted workflow targeting infrastructure that doesn't exist in this repo would always be skipped or fail.

If you want them live later, copy the YAML out of the README into `.github/workflows/`.

## Test plan

On a stock Windows machine (no AD), to validate offline mode:

- [ ] `cd ad-ldap-query`
- [ ] `.\Test-AdLdapQueryHarness.ps1` — expect all offline tests `PASS`, all live tests `SKIP`, exit 0.
- [ ] `.\Test-AdLdapQueryHarness.ps1 -Json | ConvertFrom-Json` — sanity-check structured output.

On a domain-joined Windows machine, to validate full mode:

- [ ] `$env:RUN_LIVE_AD_TESTS = '1'`
- [ ] `.\Test-AdLdapQueryHarness.ps1 -Detailed` — expect every `PASS` (or `SKIP` for live tests if and only if the operator did not opt in), exit 0.
- [ ] `.\Invoke-AdLdapQuery.ps1 -Filter '(objectClass=user)' -MaxResults 5` — sanity-check the standalone path.

## Verification limitation

The sandbox these changes were authored in has no PowerShell runtime, so the suite was **not** executed locally. PS 5.x compatibility was reviewed by-eye for known sharp edges: no `[CmdletBinding()]`, no `??` / `?:` / `&&` / `||`, no inline `if`-as-expression inside compound `Write-Host` argument lists.

https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6)_