### PR TITLE
Get-StableStringHash: Option C hybrid (HashData on PS 7+, cached MD5 on 5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ required (the project's no-install principle still holds).
   values `<= 0` and unparseable strings both clamp to "no retries"
   (one attempt total).
 
+### Performance
+
+- **`Get-StableStringHash` no longer allocates a fresh `[MD5]` instance
+  per call.** Implements Option C from #13 — runtime detection of
+  `[MD5]::HashData($bytes)` (PS 7.2+ / .NET 5+, allocation-free
+  except for the result array); on Windows PowerShell 5.1, falls
+  back to a single cached `[MD5]` instance reused across calls.
+  Output is byte-identical on both paths (pinned by the
+  `Get-StableStringHash 'hello' = 0x2a40415d` regression test and
+  the cross-process determinism test). Single-threaded by design;
+  do not call from concurrent runspaces.
+
 ## [0.2.2] - 2026-04-27
 
 Regression-coverage and CI infrastructure release. Adds dedicated

--- a/psldap.ps1
+++ b/psldap.ps1
@@ -573,6 +573,28 @@ function ConvertTo-TransformedEntry {
     return $result
 }
 
+# ----------------------------------------------------------------------------
+# MD5 capability detection & instance cache for Get-StableStringHash.
+#
+# Option C from issue #13: prefer the static [MD5]::HashData($bytes) method
+# (PS 7.2+ / .NET 5+, allocation-free except for the result array). On
+# Windows PowerShell 5.1, where HashData isn't available, fall back to a
+# single cached [MD5] instance reused across calls.
+#
+# Both paths produce byte-identical output. The pinned regression test
+# (Get-StableStringHash 'hello' = 0x2a40415d) and the cross-process
+# determinism test catch any drift.
+#
+# Caveat (single-threaded assumption): [HashAlgorithm] is not thread-safe.
+# PowerShell scripts run single-threaded by convention, but the cached
+# instance MUST NOT be used from multiple runspaces concurrently
+# (e.g. `ForEach-Object -Parallel`, runspace pools). If parallel scramble
+# is ever added, switch to per-runspace instances or the static path
+# unconditionally. See enhancement issue tracking the alternatives.
+# ----------------------------------------------------------------------------
+$script:_useHashDataStatic = ([System.Security.Cryptography.MD5].GetMethod('HashData', [Type[]]@([byte[]])) -ne $null)
+$script:_md5Instance = $null
+
 function Get-StableStringHash {
     <#
     .SYNOPSIS
@@ -586,14 +608,22 @@ function Get-StableStringHash {
     if ([string]::IsNullOrEmpty($Value)) { return 0 }
 
     $bytes = [System.Text.Encoding]::UTF8.GetBytes($Value)
-    $md5 = [System.Security.Cryptography.MD5]::Create()
-    try {
-        $hashBytes = $md5.ComputeHash($bytes)
-        return [BitConverter]::ToInt32($hashBytes, 0)
+    if ($script:_useHashDataStatic) {
+        # PS 7.2+ / .NET 5+ path — no instance, no IDisposable, allocation-free
+        # except for the returned byte[].
+        $hashBytes = [System.Security.Cryptography.MD5]::HashData($bytes)
     }
-    finally {
-        $md5.Dispose()
+    else {
+        # PS 5.1 fallback — reuse a single cached MD5 instance across calls.
+        # ComputeHash(byte[]) is a one-shot call that resets internal state,
+        # so per-call disposal isn't needed. The instance lives for process
+        # lifetime; this is fine for a CLI tool that exits cleanly.
+        if (-not $script:_md5Instance) {
+            $script:_md5Instance = [System.Security.Cryptography.MD5]::Create()
+        }
+        $hashBytes = $script:_md5Instance.ComputeHash($bytes)
     }
+    return [BitConverter]::ToInt32($hashBytes, 0)
 }
 
 function Invoke-ScrambleValue {


### PR DESCRIPTION
## Summary

Implements Option C from #13 — hybrid `[MD5]::HashData()` / cached `[MD5]` instance — in `Get-StableStringHash`. Stops allocating a fresh MD5 instance per call.

## Behaviour

| Runtime | Path |
|---------|------|
| PS 7.2+ / .NET 5+ | `[System.Security.Cryptography.MD5]::HashData($bytes)` — static, no instance, no `IDisposable`, allocation-free except for the result byte array |
| Windows PowerShell 5.1 | Single cached `[MD5]` instance reused across calls. `ComputeHash(byte[])` is a one-shot reset, so per-call `Dispose()` isn't needed. Instance lives for process lifetime. |

Capability detection runs once at script load via reflection on `MD5.GetMethod('HashData', ...)`. Cheap, runs every dot-source.

## Determinism guarantees

Output is byte-identical on both paths. Verified by existing tests:

- **Pinned regression test**: `Get-StableStringHash 'hello' = 0x2a40415d`. Gated on both PS 7+ and PS 5.1 by the workflow merged in #8.
- **Cross-process scramble determinism**: `Invoke-ScrambleValue is deterministic across separate PowerShell processes` (from #5). Spawns a fresh `pwsh`, runs the same scramble, asserts byte-equality.
- **All existing `Invoke-ScrambleValue` tests** stay green.

## Single-threaded caveat

`[HashAlgorithm]` is not thread-safe. The cached instance must not be used from concurrent runspaces (`ForEach-Object -Parallel`, runspace pools, `Start-ThreadJob`). PowerShell scripts run single-threaded by convention so this is a non-issue today. The constraint is documented inline in `psldap.ps1`. If parallel scramble is ever added, switch to per-runspace instances or the static path unconditionally.

## Deviation from #13's acceptance criteria

#13's issue body specified a benchmark before commit (≥ 20% allocation reduction on a 10k-entry workload, or close `not_planned`). **This PR ships without one** — explicit choice by the maintainer. The justification:

- The change is small (~50 lines) and reversible.
- Existing tests pin the output exactly, so a wrong implementation can't slip past CI.
- A separate enhancement issue tracks the trade-offs of Options A and B for if/when this needs to be revisited.

If real-world numbers later show no measurable win, revert is straightforward.

## What this does *not* change

- The algorithm (still MD5, used as a non-cryptographic stable mixer per the existing `Get-StableStringHash` docstring).
- The output for any input.
- The `Invoke-ScrambleValue` API or its scrambled output for a given `(Value, Seed)` pair.
- The `psldap.ps1` no-install line (no new modules, no new dependencies).
- The PS 5.1 support — covered by the fallback path.

## Test plan

- [ ] CI runs all 97 tests on both PS 7 and PS 5.1 (workflow from #8). Expect green.
- [ ] `Get-StableStringHash 'hello'` returns `0x2a40415d` on both shells (pinned).
- [ ] Cross-process determinism test passes (PR #5's regression test).

Closes #13.

https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6)_