### PR TITLE
Make test harness more robust on Windows and add iterations validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,12 @@ external module:
 .\run-tests.ps1 -Iterations 1  # quick smoke test
 ```
 
-On Windows you can also double-click [run-tests.bat](run-tests.bat).
+On Windows you can also use [run-tests.bat](run-tests.bat):
+
+```bat
+run-tests.bat                 REM defaults to -Iterations 3
+run-tests.bat -Iterations 1   REM forwards args to run-tests.ps1
+```
 
 ## License
 

--- a/run-tests.bat
+++ b/run-tests.bat
@@ -1,3 +1,25 @@
 @echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0run-tests.ps1" -Iterations 3
-pause
+setlocal
+
+set "PS_CMD="
+where powershell.exe >nul 2>&1
+if %ERRORLEVEL%==0 (
+  set "PS_CMD=powershell.exe"
+) else (
+  where pwsh.exe >nul 2>&1
+  if %ERRORLEVEL%==0 set "PS_CMD=pwsh.exe"
+)
+
+if not defined PS_CMD (
+  echo ERROR: Neither powershell.exe nor pwsh.exe was found in PATH.
+  endlocal
+  exit /b 1
+)
+
+set "SCRIPT_ARGS=%*"
+if "%SCRIPT_ARGS%"=="" set "SCRIPT_ARGS=-Iterations 3"
+
+%PS_CMD% -NoProfile -ExecutionPolicy Bypass -File "%~dp0run-tests.ps1" %SCRIPT_ARGS%
+set "TEST_EXIT=%ERRORLEVEL%"
+
+endlocal & exit /b %TEST_EXIT%

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -7,6 +7,7 @@
     .\run-tests.ps1 -Iterations 3
 #>
 param(
+    [ValidateRange(1, [int]::MaxValue)]
     [int]$Iterations = 3
 )
 


### PR DESCRIPTION
### Motivation

- Improve the Windows test wrapper so it works with both Windows PowerShell and PowerShell Core and fails cleanly if no PowerShell is available.
- Clarify `run-tests.bat` usage in the `README.md` with concrete examples.
- Validate the `-Iterations` parameter to prevent non-positive iteration counts being passed to the test harness.

### Description

- Update `README.md` to document `run-tests.bat` usage and show example invocations with default and single-iteration forms.
- Rework `run-tests.bat` to detect `powershell.exe` or `pwsh.exe`, propagate command-line arguments to `run-tests.ps1`, default to `-Iterations 3` when no args are provided, return the test process exit code, and fail with a clear message if no PowerShell is found.
- Add `[ValidateRange(1, [int]::MaxValue)]` to the `$Iterations` parameter in `run-tests.ps1` to enforce a positive integer iteration count.

### Testing

- Ran the built-in lightweight test harness via `run-tests.bat` with the default invocation (which forwards to `run-tests.ps1 -Iterations 3`) and the run completed successfully.
- Executed `run-tests.bat -Iterations 1` and `.un-tests.ps1 -Iterations 1` as quick smoke tests and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e120b60c8332aa91a498f5da2e46)