### PR TITLE
docs: document native current-user (integrated) AD authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ required (the project's no-install principle still holds).
 
 ### Documentation
 
+- **`README.md` now has an "Authentication" section.** Documents that
+  the default bind (no `-bindDN` / password) uses `AuthType::Negotiate`
+  with the current Windows logon, so queries run against Active
+  Directory as the calling user (Kerberos/NTLM via SSPI) with no
+  module install and no plaintext password. Notes that supplying
+  `-bindDN` + a password option switches to explicit `Basic` auth, and
+  that the integrated path targets on-prem AD, not cloud-only Entra ID.
 - `ad-ldap-query/README.md` now notes that `LIVE_AD_TEST_RETRIES`
   values `<= 0` and unparseable strings both clamp to "no retries"
   (one attempt total).

--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ Or just copy [psldap.ps1](psldap.ps1) anywhere on disk.
 
 Run `Get-Help .\psldap.ps1 -Detailed` for the full parameter reference.
 
+## Authentication
+
+By default — when no `-bindDN` / password is supplied — the script binds with
+**`AuthType::Negotiate` using the current Windows logon**. That means it queries
+Active Directory with the calling user's own credentials (Kerberos/NTLM via
+SSPI), exactly like the logged-on user. No password is prompted for, stored, or
+sent in plaintext, and no module or RSAT install is required.
+
+```powershell
+# Query the current user's domain with their own credentials (integrated auth)
+.\psldap.ps1 -hostname dc01.example.com `
+             -baseDN "dc=example,dc=com" `
+             -filter "(samAccountName=jdoe)"
+```
+
+Supplying `-bindDN` together with a password option (`-promptForBindPassword`,
+`-bindPassword`, or `-bindPasswordFile`) switches to explicit `Basic` auth with
+those credentials instead.
+
+> This integrated path targets on-premises Active Directory (and LDAP-enabled
+> managed domains / hybrid-synced environments). Cloud-only Microsoft Entra ID
+> has no LDAP endpoint and is not reachable this way.
+
 ## Output formats
 
 `LDIF` (default), `JSON`, `CSV`, `multi-valued-csv`, `tab-delimited`,


### PR DESCRIPTION
## Summary

Documents that PSldap can query Active Directory using the **current user's native Windows credentials**, with no module/RSAT install and no plaintext password. This was already the runtime behavior — the change makes it explicit in the docs after a verification pass.

## Verification (what was confirmed)

- **No-install on Windows 10/11:** both `psldap.ps1` and `ad-ldap-query/Invoke-AdLdapQuery.ps1` use only in-box .NET BCL types (`System.DirectoryServices.Protocols`, `System.Net`, `System.DirectoryServices*`). No `Import-Module`/RSAT, no `Install-Module`, no external executables, no Graph/Az calls. Runs on stock Windows PowerShell 5.1.
- **Current-user AD auth:** `New-LdapConnection` (`psldap.ps1`) binds with `AuthType::Negotiate` and **no credential** when `-bindDN`/password is omitted → integrated Windows auth (Kerberos/NTLM via SSPI) as the logged-on user. Supplying `-bindDN` + a password option switches to explicit `Basic` auth. The sibling `Invoke-AdLdapQuery.ps1` binds via `DirectoryEntry` with no credentials (implicit Kerberos).

## Changes

- `README.md`: new **Authentication** section with an integrated-auth example and the on-prem-AD vs. cloud-Entra-ID boundary.
- `CHANGELOG.md`: documentation entry under `[Unreleased]`.

Docs-only; no production code touched.

https://claude.ai/code/session_013LZWXDE1Aa1NYJdgfnrQGj

---
_Generated by [Claude Code](https://claude.ai/code/session_013LZWXDE1Aa1NYJdgfnrQGj)_