### PR TITLE
feat: custom-delimiter output formats for Excel-friendly export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ required (the project's no-install principle still holds).
 
 ### Added
 
+- **`delimited` / `multi-valued-delimited` output formats with a
+  `-delimiter` parameter.** Emits a header row of attribute names plus
+  one row per entry, columns joined by a caller-chosen delimiter, for
+  output that pastes cleanly into Excel. Combine with `-filter` (which
+  LDAP filter) and `-requestedAttribute` (which columns). Passing
+  `-delimiter` alone implies the `delimited` format; a delimited format
+  without `-delimiter` defaults to TAB (Excel's clipboard-paste
+  separator). Fields containing the delimiter, a `"`, or a newline are
+  CSV-style quoted so columns stay aligned. The existing `tab-delimited`
+  formats now share this engine (`Format-DelimitedOutput`) and gain the
+  same quoting; `Format-TabOutput` is a thin TAB wrapper. Covered by new
+  `Format-DelimitedField` / `Format-DelimitedOutput` unit tests.
 - **Windows PowerShell 5.1 leg in `.github/workflows/tests.yml`.**
   The `tests` workflow now matrixes `pwsh` (PowerShell 7+) and
   `powershell` (Windows PowerShell 5.1). The project explicitly

--- a/README.md
+++ b/README.md
@@ -80,11 +80,40 @@ those credentials instead.
 ## Output formats
 
 `LDIF` (default), `JSON`, `CSV`, `multi-valued-csv`, `tab-delimited`,
-`multi-valued-tab-delimited`, `dns-only`, `values-only`.
+`multi-valued-tab-delimited`, `delimited`, `multi-valued-delimited`,
+`dns-only`, `values-only`.
 
 LDIF output is RFC 2849-compliant: long lines wrap with leading-space
 continuation, values requiring it are Base64-encoded (including the
 `dn::` line when the DN contains characters that need encoding).
+
+### Custom delimiter (copy-paste into Excel)
+
+Pick the LDAP filter (`-filter`) and the columns you want (`-requestedAttribute`),
+then choose a delimiter. The `delimited` / `multi-valued-delimited` formats emit
+one header row of attribute names followed by one row per entry, columns joined
+by `-delimiter`:
+
+```powershell
+# Tab-separated — paste straight into a worksheet (TAB is Excel's paste delimiter)
+.\psldap.ps1 -filter "(objectClass=user)" `
+             -requestedAttribute cn,mail,department `
+             -delimiter "`t"
+
+# Pipe-separated, multi-valued attributes collapsed into a single cell
+.\psldap.ps1 -filter "(objectClass=group)" `
+             -requestedAttribute cn,member `
+             -outputFormat multi-valued-delimited -delimiter "|"
+```
+
+Notes:
+
+- Passing `-delimiter` alone is enough — when `-outputFormat` is omitted it
+  implies `delimited`. A delimited format without `-delimiter` defaults to TAB.
+- Fields containing the delimiter, a `"`, or a newline are CSV-style quoted
+  (inner quotes doubled), so columns stay aligned on paste.
+- `multi-valued-delimited` joins an attribute's multiple values with `|` inside
+  the cell; plain `delimited` keeps only the first value.
 
 File output is written as **UTF-8 without BOM** so downstream LDIF / CSV
 consumers don't choke on the byte-order mark that Windows PowerShell 5.1

--- a/psldap.Tests.ps1
+++ b/psldap.Tests.ps1
@@ -520,6 +520,77 @@ Describe 'Format-TabOutput' {
 }
 
 # ============================================================================
+# Format-DelimitedField Tests
+# ============================================================================
+Describe 'Format-DelimitedField' {
+    It 'Returns empty string for null/empty' {
+        Assert-Equal '' (Format-DelimitedField -Value $null -Delimiter ',')
+        Assert-Equal '' (Format-DelimitedField -Value '' -Delimiter '|')
+    }
+
+    It 'Leaves plain values unquoted' {
+        Assert-Equal 'hello' (Format-DelimitedField -Value 'hello' -Delimiter ',')
+    }
+
+    It 'Quotes when the value contains the delimiter' {
+        Assert-Equal '"a|b"' (Format-DelimitedField -Value 'a|b' -Delimiter '|')
+        # A comma is NOT special when the delimiter is a pipe.
+        Assert-Equal 'a,b' (Format-DelimitedField -Value 'a,b' -Delimiter '|')
+    }
+
+    It 'Quotes and doubles embedded double-quotes' {
+        Assert-Equal '"say ""hi"""' (Format-DelimitedField -Value 'say "hi"' -Delimiter ',')
+    }
+
+    It 'Quotes when the value contains a newline' {
+        Assert-Equal "`"l1`nl2`"" (Format-DelimitedField -Value "l1`nl2" -Delimiter ',')
+    }
+}
+
+# ============================================================================
+# Format-DelimitedOutput Tests
+# ============================================================================
+Describe 'Format-DelimitedOutput' {
+    It 'Joins columns with the supplied delimiter' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; cn = @('John'); mail = @('john@t.com') })
+        $lines = (Format-DelimitedOutput -Entries $entries -Columns @('cn','mail') -Delimiter '|') -split "`r?`n" | Where-Object { $_ }
+        Assert-Equal 'cn|mail' $lines[0]
+        Assert-Equal 'John|john@t.com' $lines[1]
+    }
+
+    It 'Defaults to a TAB delimiter' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; cn = @('John') })
+        $lines = (Format-DelimitedOutput -Entries $entries -Columns @('cn')) -split "`r?`n" | Where-Object { $_ }
+        Assert-Equal 'cn' $lines[0]
+        Assert-Equal 'John' $lines[1]
+    }
+
+    It 'Quotes a field that contains the delimiter' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; cn = @('Doe, John') })
+        $lines = (Format-DelimitedOutput -Entries $entries -Columns @('cn') -Delimiter ',') -split "`r?`n" | Where-Object { $_ }
+        Assert-Equal '"Doe, John"' $lines[1]
+    }
+
+    It 'Single-valued takes only the first value' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; mail = @('a@t.com','b@t.com') })
+        $lines = (Format-DelimitedOutput -Entries $entries -Columns @('mail') -Delimiter ',') -split "`r?`n" | Where-Object { $_ }
+        Assert-Equal 'a@t.com' $lines[1]
+    }
+
+    It 'Multi-valued joins values with a pipe inside the cell' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; mail = @('a@t.com','b@t.com') })
+        $lines = @((Format-DelimitedOutput -Entries $entries -Columns @('mail') -Delimiter ',' -MultiValued) -split "`r?`n" | Where-Object { $_ })
+        Assert-Equal 'a@t.com|b@t.com' $lines[1]
+    }
+
+    It 'Emits an empty cell for a missing attribute' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; cn = @('John') })
+        $lines = (Format-DelimitedOutput -Entries $entries -Columns @('cn','mail') -Delimiter ',') -split "`r?`n" | Where-Object { $_ }
+        Assert-Equal 'John,' $lines[1]
+    }
+}
+
+# ============================================================================
 # Format-DnsOnlyOutput Tests
 # ============================================================================
 Describe 'Format-DnsOnlyOutput' {

--- a/psldap.ps1
+++ b/psldap.ps1
@@ -92,7 +92,21 @@
 
 .PARAMETER outputFormat
     Output format: LDIF, JSON, CSV, multi-valued-csv, tab-delimited,
-    multi-valued-tab-delimited, dns-only, or values-only. Default: LDIF.
+    multi-valued-tab-delimited, delimited, multi-valued-delimited,
+    dns-only, or values-only. Default: LDIF.
+
+    The 'delimited' / 'multi-valued-delimited' formats emit one header row of
+    attribute names followed by one row per entry, with columns joined by the
+    -delimiter string. Fields containing the delimiter, a double-quote, or a
+    newline are CSV-style quoted, so the result pastes cleanly into Excel.
+
+.PARAMETER delimiter
+    Column delimiter for the 'delimited' / 'multi-valued-delimited' output
+    formats. Specifying -delimiter is enough to select delimited output:
+    when -outputFormat is not given explicitly, -delimiter implies
+    'delimited'. Defaults to a TAB when a delimited format is selected
+    without -delimiter (TAB is what Excel uses for clipboard paste).
+    Common choices: "`t" (tab), "," (comma), "|" (pipe), ";" (semicolon).
 
 .PARAMETER outputFile
     Path to write search results. If not specified, results go to standard output.
@@ -148,6 +162,14 @@
 
 .EXAMPLE
     .\psldap.ps1 -ldapURLFile ./urls.txt -outputFormat LDIF -continueOnError
+
+.EXAMPLE
+    # Tab-delimited columns, ready to paste straight into Excel
+    .\psldap.ps1 -filter "(objectClass=user)" -requestedAttribute cn,mail,department -delimiter "`t"
+
+.EXAMPLE
+    # Pipe-delimited, collapsing multi-valued attributes into one cell
+    .\psldap.ps1 -filter "(objectClass=group)" -requestedAttribute cn,member -outputFormat multi-valued-delimited -delimiter "|"
 #>
 
 [CmdletBinding()]
@@ -255,8 +277,11 @@ param (
 
     # Output
     [ValidateSet('LDIF', 'JSON', 'CSV', 'multi-valued-csv', 'tab-delimited',
-        'multi-valued-tab-delimited', 'dns-only', 'values-only')]
+        'multi-valued-tab-delimited', 'delimited', 'multi-valued-delimited',
+        'dns-only', 'values-only')]
     [string]$outputFormat = 'LDIF',
+
+    [string]$delimiter,
 
     [ValidateScript({
         if ($_) {
@@ -856,21 +881,44 @@ function Format-CsvField {
     return $Value
 }
 
-function Format-TabOutput {
+function Format-DelimitedField {
     <#
     .SYNOPSIS
-        Formats entries as tab-delimited output.
+        Escapes a single field for delimited output. Quotes (CSV-style, with
+        doubled inner quotes) when the value contains the delimiter, a
+        double-quote, or a line break — so the row stays aligned and pastes
+        cleanly into Excel regardless of which delimiter was chosen.
+    #>
+    param(
+        [string]$Value,
+        [string]$Delimiter
+    )
+
+    if ([string]::IsNullOrEmpty($Value)) { return '' }
+    if ($Value.Contains($Delimiter) -or $Value -match '["\r\n]') {
+        return '"' + ($Value -replace '"', '""') + '"'
+    }
+    return $Value
+}
+
+function Format-DelimitedOutput {
+    <#
+    .SYNOPSIS
+        Formats entries as delimiter-separated columns: one header row of
+        attribute names, then one row per entry. Used by the tab-delimited and
+        the generic 'delimited' output formats.
     #>
     param(
         [array]$Entries,
         [string[]]$Columns,
+        [string]$Delimiter = "`t",
         [switch]$MultiValued
     )
 
     $sb = [System.Text.StringBuilder]::new()
 
     # Header
-    [void]$sb.AppendLine($Columns -join "`t")
+    [void]$sb.AppendLine((($Columns | ForEach-Object { Format-DelimitedField -Value $_ -Delimiter $Delimiter }) -join $Delimiter))
 
     foreach ($entry in $Entries) {
         $row = @()
@@ -880,16 +928,31 @@ function Format-TabOutput {
                 $row += ''
             }
             elseif ($MultiValued) {
-                $row += ($vals -join '|')
+                $row += Format-DelimitedField -Value (($vals) -join '|') -Delimiter $Delimiter
             }
             else {
-                $row += $vals[0]
+                $row += Format-DelimitedField -Value ($vals[0]) -Delimiter $Delimiter
             }
         }
-        [void]$sb.AppendLine($row -join "`t")
+        [void]$sb.AppendLine($row -join $Delimiter)
     }
 
     return $sb.ToString()
+}
+
+function Format-TabOutput {
+    <#
+    .SYNOPSIS
+        Formats entries as tab-delimited output. Thin wrapper over
+        Format-DelimitedOutput with a TAB delimiter.
+    #>
+    param(
+        [array]$Entries,
+        [string[]]$Columns,
+        [switch]$MultiValued
+    )
+
+    return Format-DelimitedOutput -Entries $Entries -Columns $Columns -Delimiter "`t" -MultiValued:$MultiValued
 }
 
 function Format-DnsOnlyOutput {
@@ -934,6 +997,7 @@ function Write-SearchOutput {
         [array]$Entries,
         [string]$Format,
         [string[]]$Columns,
+        [string]$Delimiter = "`t",
         [string]$OutFile,
         [switch]$TeeToStdOut,
         [int]$WrapCol,
@@ -948,6 +1012,8 @@ function Write-SearchOutput {
         'multi-valued-csv' { Format-CsvOutput -Entries $Entries -Columns $Columns -MultiValued }
         'tab-delimited' { Format-TabOutput -Entries $Entries -Columns $Columns }
         'multi-valued-tab-delimited' { Format-TabOutput -Entries $Entries -Columns $Columns -MultiValued }
+        'delimited' { Format-DelimitedOutput -Entries $Entries -Columns $Columns -Delimiter $Delimiter }
+        'multi-valued-delimited' { Format-DelimitedOutput -Entries $Entries -Columns $Columns -Delimiter $Delimiter -MultiValued }
         'dns-only' { Format-DnsOnlyOutput -Entries $Entries }
         'values-only' { Format-ValuesOnlyOutput -Entries $Entries }
     }
@@ -1166,7 +1232,7 @@ function Invoke-SearchAndOutput {
     }
 
     $columns = @()
-    if ($script:outputFormat -in @('CSV', 'multi-valued-csv', 'tab-delimited', 'multi-valued-tab-delimited')) {
+    if ($script:outputFormat -in @('CSV', 'multi-valued-csv', 'tab-delimited', 'multi-valued-tab-delimited', 'delimited', 'multi-valued-delimited')) {
         if ($Attrs.Count -gt 0) {
             $columns = $Attrs
         }
@@ -1194,6 +1260,7 @@ function Invoke-SearchAndOutput {
         -Entries $transformedEntries `
         -Format $script:outputFormat `
         -Columns $columns `
+        -Delimiter $script:delimiter `
         -OutFile $currentOutFile `
         -TeeToStdOut:$script:teeResultsToStandardOut `
         -WrapCol $script:wrapColumn `
@@ -1253,6 +1320,30 @@ if ($teeResultsToStandardOut -and -not $outputFile) {
 
 if ($separateOutputFilePerSearch -and -not $outputFile) {
     Write-Warning "-separateOutputFilePerSearch has no effect without -outputFile."
+}
+
+# --- Resolve delimited output options ---
+# Specifying -delimiter is enough to select delimited output: when the caller
+# didn't pass an explicit -outputFormat, -delimiter implies 'delimited'.
+if ($PSBoundParameters.ContainsKey('delimiter') -and -not $PSBoundParameters.ContainsKey('outputFormat')) {
+    $outputFormat = 'delimited'
+}
+
+if ($outputFormat -in @('delimited', 'multi-valued-delimited')) {
+    if ($PSBoundParameters.ContainsKey('delimiter')) {
+        if ([string]::IsNullOrEmpty($delimiter)) {
+            Write-Error "-delimiter cannot be empty."
+            exit 1
+        }
+    }
+    else {
+        # No delimiter given for a delimited format: default to TAB, which is
+        # the column separator Excel expects on a clipboard paste.
+        $delimiter = "`t"
+    }
+}
+elseif ($PSBoundParameters.ContainsKey('delimiter')) {
+    Write-Warning "-delimiter has no effect with -outputFormat '$outputFormat'."
 }
 
 # --- Resolve hostname ---


### PR DESCRIPTION
## Summary

Adds a custom-delimiter export so you can pick the LDAP filter and the columns, then get a table that pastes straight into Excel. Builds on the existing `-filter` (which records) and `-requestedAttribute` (which columns) options.

## What's new

- **`delimited` / `multi-valued-delimited` output formats** + a **`-delimiter`** parameter. Emits one header row of attribute names, then one row per entry, columns joined by the chosen delimiter.
- **`-delimiter` alone is enough** — when `-outputFormat` is omitted, `-delimiter` implies `delimited`. A delimited format with no `-delimiter` defaults to **TAB** (the separator Excel uses on a clipboard paste).
- **Excel-safe quoting:** fields containing the delimiter, a `"`, or a newline are CSV-style quoted (inner quotes doubled), so columns stay aligned on paste.
- `multi-valued-delimited` collapses an attribute's multiple values into one cell (joined with `|`); plain `delimited` keeps the first value.

```powershell
# Tab-separated, paste into a worksheet
.\psldap.ps1 -filter "(objectClass=user)" -requestedAttribute cn,mail,department -delimiter "`t"

# Pipe-separated, multi-valued attributes in one cell
.\psldap.ps1 -filter "(objectClass=group)" -requestedAttribute cn,member -outputFormat multi-valued-delimited -delimiter "|"
```

## Implementation notes

- The existing `tab-delimited` formats now share a single `Format-DelimitedOutput` engine (with a `Format-DelimitedField` quoting helper). `Format-TabOutput` is now a thin TAB wrapper, so existing tab behavior is preserved (the pinned `Format-TabOutput` test still passes) and gains the same quoting.
- No new modules or external dependencies — still native .NET BCL only.

## Tests / docs

- New unit tests: `Format-DelimitedField` (quoting rules) and `Format-DelimitedOutput` (delimiter, defaults, multi-valued, empty cells).
- README "Output formats" section documents the delimiter usage; CHANGELOG updated under `[Unreleased]`.

https://claude.ai/code/session_013LZWXDE1Aa1NYJdgfnrQGj

---
_Generated by [Claude Code](https://claude.ai/code/session_013LZWXDE1Aa1NYJdgfnrQGj)_