### PR TITLE
test: shell-agnostic run-tests.bat + validate -Iterations (reimplements #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ required (the project's no-install principle still holds).
 
 ### Added
 
+- **`run-tests.bat` now works with either PowerShell and propagates the
+  exit code.** Detects `powershell.exe` (Windows PowerShell) or
+  `pwsh.exe` (PowerShell 7+), forwards its arguments to `run-tests.ps1`
+  (defaulting to `-Iterations 3` when none are given), returns the test
+  process's exit code so it can gate CI, and fails with a clear message
+  if no PowerShell is found. The shell detection uses `&&` on each
+  `where` check rather than reading `%ERRORLEVEL%` inside an `if/else`
+  block (which expands at parse time and would never reach the
+  `pwsh.exe` fallback). Reworks the idea from #16 with that bug fixed.
+- **`-Iterations` validation in `run-tests.ps1`.** Adds
+  `[ValidateRange(1, [int]::MaxValue)]` so non-positive iteration counts
+  are rejected up front instead of silently running zero iterations.
+  (From #16.)
 - **`delimited` / `multi-valued-delimited` output formats with a
   `-delimiter` parameter.** Emits a header row of attribute names plus
   one row per entry, columns joined by a caller-chosen delimiter, for

--- a/README.md
+++ b/README.md
@@ -253,7 +253,17 @@ external module:
 .\run-tests.ps1 -Iterations 1  # quick smoke test
 ```
 
-On Windows you can also double-click [run-tests.bat](run-tests.bat).
+On Windows you can also use [run-tests.bat](run-tests.bat):
+
+```bat
+run-tests.bat                 REM defaults to -Iterations 3
+run-tests.bat -Iterations 1   REM forwards args to run-tests.ps1
+```
+
+The wrapper detects `powershell.exe` (Windows PowerShell) or `pwsh.exe`
+(PowerShell 7+), forwards its arguments to `run-tests.ps1`, and returns the
+test process's exit code (so it works in CI), failing with a clear message if
+no PowerShell is found.
 
 ## License
 

--- a/run-tests.bat
+++ b/run-tests.bat
@@ -1,3 +1,28 @@
 @echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0run-tests.ps1" -Iterations 3
-pause
+setlocal
+
+REM Prefer Windows PowerShell; fall back to PowerShell 7 (pwsh) if it isn't
+REM present. Each `where` is gated with `&&` so the check uses that command's
+REM own exit code at run time -- reading %ERRORLEVEL% inside an if/else block
+REM expands at parse time and would always see the first check's result.
+set "PS_CMD="
+where powershell.exe >nul 2>&1 && set "PS_CMD=powershell.exe"
+if not defined PS_CMD (
+  where pwsh.exe >nul 2>&1 && set "PS_CMD=pwsh.exe"
+)
+
+if not defined PS_CMD (
+  echo ERROR: Neither powershell.exe nor pwsh.exe was found in PATH.
+  endlocal
+  exit /b 1
+)
+
+REM Default to -Iterations 3 when run with no args; otherwise forward whatever
+REM the caller passed straight through to run-tests.ps1.
+set "SCRIPT_ARGS=%*"
+if "%SCRIPT_ARGS%"=="" set "SCRIPT_ARGS=-Iterations 3"
+
+"%PS_CMD%" -NoProfile -ExecutionPolicy Bypass -File "%~dp0run-tests.ps1" %SCRIPT_ARGS%
+set "TEST_EXIT=%ERRORLEVEL%"
+
+endlocal & exit /b %TEST_EXIT%

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -7,6 +7,7 @@
     .\run-tests.ps1 -Iterations 3
 #>
 param(
+    [ValidateRange(1, [int]::MaxValue)]
     [int]$Iterations = 3
 )
 


### PR DESCRIPTION
## Summary

Reimplements **#16** ("Make test harness more robust on Windows…") cleanly on current `main`, keeping the good parts and fixing a bug in the proposed `run-tests.bat`.

## Changes

- **`run-tests.bat`** — detects `powershell.exe` (Windows PowerShell) or `pwsh.exe` (PowerShell 7+), forwards its arguments to `run-tests.ps1` (defaulting to `-Iterations 3` when none are given), returns the test process's exit code so it can gate CI, and fails with a clear message if no PowerShell is found.
- **`run-tests.ps1`** — adds `[ValidateRange(1, [int]::MaxValue)]` to `-Iterations` (rejects non-positive counts up front). *(unchanged from #16)*
- **`README.md`** — documents the wrapper's CLI usage. CHANGELOG updated.

## Why not just merge #16

#16's `run-tests.bat` had a cmd.exe **delayed-expansion bug**: it read `%ERRORLEVEL%` inside an `if/else` block to detect `pwsh.exe`, but that block expands at parse time, so the inner check always saw the *outer* `where powershell.exe` result — meaning the `pwsh.exe` fallback never triggered on a PowerShell-7-only machine (the exact case the PR set out to support). Its CI was green only because `windows-latest` always has `powershell.exe`, so the broken path was never exercised.

This version gates each `where` with `&&` (runtime exit-code check) instead of reading `%ERRORLEVEL%` in a block, so the fallback works correctly. `#16` will be closed in favor of this PR (credit to the original author for the idea).

## CI

Touches `run-tests.ps1`, so the test workflow (PS 5.1 + PS 7) runs in addition to CodeQL.

https://claude.ai/code/session_013LZWXDE1Aa1NYJdgfnrQGj

---
_Generated by [Claude Code](https://claude.ai/code/session_013LZWXDE1Aa1NYJdgfnrQGj)_