### PR TITLE
Get-StableStringHash: Option A — cached MD5 only (Stage 1 of #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,15 +80,16 @@ required (the project's no-install principle still holds).
 
 ### Performance
 
-- **`Get-StableStringHash` no longer allocates a fresh `[MD5]` instance
-  per call.** Implements Option C from #13 — runtime detection of
-  `[MD5]::HashData($bytes)` (PS 7.2+ / .NET 5+, allocation-free
-  except for the result array); on Windows PowerShell 5.1, falls
-  back to a single cached `[MD5]` instance reused across calls.
-  Output is byte-identical on both paths (pinned by the
+- **`Get-StableStringHash` reuses a single cached `[MD5]` instance
+  across calls instead of allocating a fresh one each time.**
+  Implements Option A from #15 (simplifies the runtime-branched
+  Option C from #13 — never released — to a single cached-instance
+  path on both PS 7+ and PS 5.1). `ComputeHash(byte[])` is a
+  one-shot reset, so per-call disposal isn't needed; the instance
+  lives for process lifetime. Output unchanged — the pinned
   `Get-StableStringHash 'hello' = 0x2a40415d` regression test and
-  the cross-process determinism test). Single-threaded by design;
-  do not call from concurrent runspaces.
+  the cross-process determinism test both still hold. Single-
+  threaded by design; do not call from concurrent runspaces.
 
 ## [0.2.2] - 2026-04-27
 

--- a/psldap.ps1
+++ b/psldap.ps1
@@ -599,25 +599,21 @@ function ConvertTo-TransformedEntry {
 }
 
 # ----------------------------------------------------------------------------
-# MD5 capability detection & instance cache for Get-StableStringHash.
+# Cached MD5 instance for Get-StableStringHash.
 #
-# Option C from issue #13: prefer the static [MD5]::HashData($bytes) method
-# (PS 7.2+ / .NET 5+, allocation-free except for the result array). On
-# Windows PowerShell 5.1, where HashData isn't available, fall back to a
-# single cached [MD5] instance reused across calls.
-#
-# Both paths produce byte-identical output. The pinned regression test
-# (Get-StableStringHash 'hello' = 0x2a40415d) and the cross-process
-# determinism test catch any drift.
+# Option A from issue #15: reuse a single [MD5] instance across calls
+# instead of allocating one per call. ComputeHash(byte[]) is a one-shot
+# call that resets internal state, so per-call disposal isn't needed.
+# The instance lives for process lifetime; fine for a CLI tool that
+# exits cleanly.
 #
 # Caveat (single-threaded assumption): [HashAlgorithm] is not thread-safe.
 # PowerShell scripts run single-threaded by convention, but the cached
 # instance MUST NOT be used from multiple runspaces concurrently
 # (e.g. `ForEach-Object -Parallel`, runspace pools). If parallel scramble
-# is ever added, switch to per-runspace instances or the static path
-# unconditionally. See enhancement issue tracking the alternatives.
+# is ever added, switch to per-runspace instances or move to Option B
+# (static `[SHA256]::HashData`) per issue #15.
 # ----------------------------------------------------------------------------
-$script:_useHashDataStatic = ([System.Security.Cryptography.MD5].GetMethod('HashData', [Type[]]@([byte[]])) -ne $null)
 $script:_md5Instance = $null
 
 function Get-StableStringHash {
@@ -633,21 +629,10 @@ function Get-StableStringHash {
     if ([string]::IsNullOrEmpty($Value)) { return 0 }
 
     $bytes = [System.Text.Encoding]::UTF8.GetBytes($Value)
-    if ($script:_useHashDataStatic) {
-        # PS 7.2+ / .NET 5+ path — no instance, no IDisposable, allocation-free
-        # except for the returned byte[].
-        $hashBytes = [System.Security.Cryptography.MD5]::HashData($bytes)
+    if (-not $script:_md5Instance) {
+        $script:_md5Instance = [System.Security.Cryptography.MD5]::Create()
     }
-    else {
-        # PS 5.1 fallback — reuse a single cached MD5 instance across calls.
-        # ComputeHash(byte[]) is a one-shot call that resets internal state,
-        # so per-call disposal isn't needed. The instance lives for process
-        # lifetime; this is fine for a CLI tool that exits cleanly.
-        if (-not $script:_md5Instance) {
-            $script:_md5Instance = [System.Security.Cryptography.MD5]::Create()
-        }
-        $hashBytes = $script:_md5Instance.ComputeHash($bytes)
-    }
+    $hashBytes = $script:_md5Instance.ComputeHash($bytes)
     return [BitConverter]::ToInt32($hashBytes, 0)
 }
 


### PR DESCRIPTION
## Summary

Stage 1 of the staged plan for #15. Simplifies `Get-StableStringHash` from the runtime-branched Option C hybrid (currently on `main`, never released) to **Option A** — an unconditional cached `[MD5]` instance. No support-matrix change; no runtime-trigger required.

Stage 2 (Option B + SHA256, drops PS 5.1) remains deferred and is tracked by #15 itself.

## What changed in `psldap.ps1`

- Dropped the `$script:_useHashDataStatic` capability check at script load. No more reflection lookup on `MD5.GetMethod('HashData', ...)`.
- Dropped the per-call `if/else` branch in `Get-StableStringHash`. The function now always: lazy-init the cached instance on first call, then `ComputeHash(byte[])`. `ComputeHash` is a one-shot reset so the instance is safely reusable across calls.
- Updated the inline comment block to describe Option A and reference #15. The single-threaded caveat stays, with a forward-pointer to Option B for if/when it becomes blocking (parallel scramble, etc.).

## What changed in `CHANGELOG.md`

The `[Unreleased]` Performance entry previously described Option C (added in #14, never released). Reworded to describe Option A and reference #15. **Not adding a new entry** — Stage 1 supersedes the never-released Option C, so the CHANGELOG just reflects the final shape that'll cut for the next release.

## Output guarantees

Both still hold, byte-identical to current `main`:

- `Get-StableStringHash 'hello'` → `0x2a40415d` (pinned regression test at `psldap.Tests.ps1:167`).
- Cross-process scramble determinism (test from #5).
- `Invoke-ScrambleValue` output for any `(Value, Seed)` pair.

The optimization changes only how the hash is computed internally, not what it returns.

## CI

Touches `psldap.ps1`, so the test workflow (PS 5.1 + PS 7) runs. Expect both legs green — same algorithm, same pinned constant, same cross-process determinism.

## Stats

| | Before | After |
|---|---|---|
| Lines in `Get-StableStringHash` + state + comment | 53 | 36 |
| Script-scope state | `$script:_useHashDataStatic`, `$script:_md5Instance` | `$script:_md5Instance` |
| Per-call branches | 1 (`if` on capability) | 0 (the lazy-init check is one-shot — only `null` on first call) |
| Reflection at script load | 1 (`MD5.GetMethod('HashData', ...)`) | 0 |
| New module dependencies | 0 | 0 |

## What this PR does *not* do

- Doesn't change the hash algorithm (still MD5).
- Doesn't change `Get-StableStringHash` output for any input.
- Doesn't change `Invoke-ScrambleValue`'s scrambled output for any `(Value, Seed)` pair.
- Doesn't change the PS 5.1 / PS 7+ support matrix.
- Doesn't address Stage 2 (Option B + SHA256). Tracked separately by #15.

## Closes / refs

- Does **not** close #15 — #15 stays open to track Stage 2. The Stage 2 section of #15 describes the trigger conditions and the SHA256-with-breaking-change implementation plan.

https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6)_