### PR TITLE
Cut 0.3.0: promote [Unreleased] → [0.3.0] - 2026-06-21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to PSldap are documented here.
 
 ## [Unreleased]
 
-> ⚠️ **BREAKING — this release will be `0.3.0` when cut.** Two
+_No changes yet._
+
+## [0.3.0] - 2026-06-21
+
+> ⚠️ **BREAKING.** Two
 > independent breaking changes; both are explicit choices documented
 > below.
 >


### PR DESCRIPTION
## Summary

Maintainer-cut step from #22's release instructions. Promotes the `[Unreleased]` section (already populated with the BREAKING content from #22) under a dated `[0.3.0] - 2026-06-21` heading, and adds an empty `[Unreleased]` placeholder above it for future entries.

## CI

`CHANGELOG.md`-only. Won't trigger `tests.yml` (path-filtered). Only `Analyze (actions)` / `CodeQL` will run.

## Post-merge

Once this lands, I'll create the `v0.3.0` tag from `main` and (if MCP exposes it) the corresponding GitHub Release. Otherwise I'll hand back the exact commands.

https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiVnZDW9nkpWDAfGurUYY6)_