### PR TITLE
perf: replace O(n²) array += loops with List[T] in five hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,29 @@ All notable changes to PSldap are documented here.
 
 ## [Unreleased]
 
-_No changes yet._
+### Changed
+
+- **Eliminated O(n²) array-growth in all hot paths.** Five functions were
+  using `$array += item` inside loops, which copies the entire array on
+  every iteration. Replaced with `List[T]::new()` + `.Add()` + `.ToArray()`
+  in `Read-FiltersFromFile`, `Read-SearchSpecsFromLdapURLFile`,
+  `ConvertTo-TransformedEntry` (per-attribute value accumulation),
+  `Format-JsonOutput`, and `Invoke-SearchAndOutput`. The main-block
+  `$searchSpecs` loop accumulation was also converted. Public API and
+  return types are unchanged — all callers receive plain arrays.
+
+### Tests
+
+- **`Write-SearchOutput` format-dispatch coverage expanded.** Added six new
+  tests: JSON dispatch (parses output as JSON and checks `dn`), CSV dispatch
+  (header + data row), delimited dispatch with a custom delimiter (`|`),
+  values-only dispatch, LDIF terse dispatch (no `version: 1` header), and
+  the tee-to-stdout path (`-TeeToStdOut`). Previously only file-write and
+  dns-only were covered.
+- **Three new source-code regression guards** in the `Source-Code Checks`
+  block assert that `$transformedEntries +=`, `$filters +=`, and `$specs +=`
+  do not reappear in `psldap.ps1`, preventing an accidental revert of the
+  List-based hot-path fixes above.
 
 ## [0.3.0] - 2026-06-21
 

--- a/psldap.Tests.ps1
+++ b/psldap.Tests.ps1
@@ -766,6 +766,54 @@ Describe 'Write-SearchOutput' {
         $result = Write-SearchOutput -Entries $entries -Format 'dns-only' -WrapCol 76
         Assert-Match ($result -join '') 'cn=test,dc=com'
     }
+
+    It 'Dispatches to JSON format and returns valid JSON' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; cn = @('test') })
+        $result = Write-SearchOutput -Entries $entries -Format 'JSON' -WrapCol 76
+        $parsed = @($result | ConvertFrom-Json)
+        Assert-Equal 1 $parsed.Count
+        Assert-Equal 'cn=test,dc=com' $parsed[0].dn
+    }
+
+    It 'Dispatches to CSV format with correct header and row' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; cn = @('Alice'); mail = @('alice@example.com') })
+        $lines = (Write-SearchOutput -Entries $entries -Format 'CSV' -Columns @('cn','mail') -WrapCol 76) -split "`r?`n" | Where-Object { $_ }
+        Assert-Equal 'cn,mail' $lines[0]
+        Assert-Equal 'Alice,alice@example.com' $lines[1]
+    }
+
+    It 'Dispatches to delimited format with a custom delimiter' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; cn = @('Bob'); dept = @('Eng') })
+        $lines = (Write-SearchOutput -Entries $entries -Format 'delimited' -Columns @('cn','dept') -Delimiter '|' -WrapCol 76) -split "`r?`n" | Where-Object { $_ }
+        Assert-Equal 'cn|dept' $lines[0]
+        Assert-Equal 'Bob|Eng' $lines[1]
+    }
+
+    It 'Dispatches to values-only format' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; cn = @('Charlie') })
+        $result = Write-SearchOutput -Entries $entries -Format 'values-only' -WrapCol 76
+        Assert-Match ($result -join '') 'Charlie'
+    }
+
+    It 'Dispatches to LDIF terse format (no version header)' {
+        $entries = @([ordered]@{ dn = 'cn=test,dc=com'; cn = @('test') })
+        $result = (Write-SearchOutput -Entries $entries -Format 'LDIF' -WrapCol 76 -Terse) -join ''
+        Assert-NotMatch $result 'version: 1'
+        Assert-Match $result 'dn: cn=test,dc=com'
+    }
+
+    It 'Tees output to stdout when -TeeToStdOut and file path both given' {
+        $outPath = Join-Path $env:TEMP 'psldap_test_tee.ldif'
+        try {
+            $entries = @([ordered]@{ dn = 'cn=tee,dc=com'; cn = @('tee') })
+            $stdout = Write-SearchOutput -Entries $entries -Format 'LDIF' -WrapCol 76 -OutFile $outPath -TeeToStdOut
+            Assert-True (Test-Path $outPath)
+            Assert-Match ($stdout -join '') 'cn=tee,dc=com'
+        }
+        finally {
+            if (Test-Path $outPath) { Remove-Item $outPath -Force }
+        }
+    }
 }
 
 # ============================================================================
@@ -819,6 +867,27 @@ Describe 'Source-Code Checks' {
         $scriptPath = Join-Path $PSScriptRoot 'psldap.ps1'
         $content = Get-Content -Path $scriptPath -Raw
         Assert-NotMatch $content '\[(System\.Collections\.Generic\.)?LinkedHashSet'
+    }
+
+    It 'Invoke-SearchAndOutput accumulates transformed entries with List.Add, not += (O(n) growth)' {
+        # Regression guard: using $transformedEntries += in a loop creates a new
+        # array on every iteration, making entry processing O(n^2). The fix is
+        # List[object]::new() + .Add(). This check ensures the fix is not reverted.
+        $scriptPath = Join-Path $PSScriptRoot 'psldap.ps1'
+        $content = Get-Content -Path $scriptPath -Raw
+        Assert-NotMatch $content '\$transformedEntries\s*\+='
+    }
+
+    It 'Read-FiltersFromFile accumulates filters with List.Add, not += (O(n) growth)' {
+        $scriptPath = Join-Path $PSScriptRoot 'psldap.ps1'
+        $content = Get-Content -Path $scriptPath -Raw
+        Assert-NotMatch $content '\$filters\s*\+='
+    }
+
+    It 'Read-SearchSpecsFromLdapURLFile accumulates specs with List.Add, not += (O(n) growth)' {
+        $scriptPath = Join-Path $PSScriptRoot 'psldap.ps1'
+        $content = Get-Content -Path $scriptPath -Raw
+        Assert-NotMatch $content '\$specs\s*\+='
     }
 }
 

--- a/psldap.ps1
+++ b/psldap.ps1
@@ -475,7 +475,7 @@ function Read-FiltersFromFile {
     #>
     param([string]$Path)
 
-    $filters = @()
+    $filters = [System.Collections.Generic.List[string]]::new()
     $lineNum = 0
     foreach ($line in (Get-Content -Path $Path)) {
         $lineNum++
@@ -485,10 +485,10 @@ function Read-FiltersFromFile {
                 Write-Warning "Skipping invalid filter at line ${lineNum}: $trimmed"
                 continue
             }
-            $filters += $trimmed
+            $filters.Add($trimmed)
         }
     }
-    return $filters
+    return $filters.ToArray()
 }
 
 function Read-SearchSpecsFromLdapURLFile {
@@ -499,7 +499,7 @@ function Read-SearchSpecsFromLdapURLFile {
     #>
     param([string]$Path)
 
-    $specs = @()
+    $specs = [System.Collections.Generic.List[hashtable]]::new()
     foreach ($line in (Get-Content -Path $Path)) {
         $trimmed = $line.Trim()
         if (-not $trimmed -or $trimmed.StartsWith('#')) { continue }
@@ -530,9 +530,9 @@ function Read-SearchSpecsFromLdapURLFile {
             scope      = $(if ($parts.Count -ge 3 -and $parts[2]) { $parts[2] } else { $null })
             filter     = $parsedFilter
         }
-        $specs += $spec
+        $specs.Add($spec)
     }
-    return $specs
+    return $specs.ToArray()
 }
 
 function ConvertTo-TransformedEntry {
@@ -561,17 +561,18 @@ function ConvertTo-TransformedEntry {
             continue
         }
 
-        $values = @()
+        $valueList = [System.Collections.Generic.List[string]]::new()
         $attr = $Entry.Attributes[$attrName]
         for ($i = 0; $i -lt $attr.Count; $i++) {
             $val = $attr[$i]
             if ($val -is [byte[]]) {
-                $values += [Convert]::ToBase64String($val)
+                $valueList.Add([Convert]::ToBase64String($val))
             }
             else {
-                $values += $val.ToString()
+                $valueList.Add($val.ToString())
             }
         }
+        $values = $valueList.ToArray()
 
         # Redact check
         if ($RedactAttributes -and ($RedactAttributes | Where-Object { $_.ToLower() -eq $attrNameLower })) {
@@ -777,7 +778,7 @@ function Format-JsonOutput {
     #>
     param([array]$Entries)
 
-    $objects = @()
+    $objects = [System.Collections.Generic.List[PSCustomObject]]::new()
     foreach ($entry in $Entries) {
         $obj = [ordered]@{ dn = $entry.dn }
         foreach ($key in $entry.Keys) {
@@ -790,7 +791,7 @@ function Format-JsonOutput {
                 $obj[$key] = $vals
             }
         }
-        $objects += [PSCustomObject]$obj
+        $objects.Add([PSCustomObject]$obj)
     }
 
     if ($objects.Count -eq 0) {
@@ -1191,15 +1192,15 @@ function Invoke-SearchAndOutput {
         -DryRunFlag:$script:dryRun `
         -RateLimit $script:ratePerSecond
 
-    $transformedEntries = @()
+    $transformedEntries = [System.Collections.Generic.List[object]]::new()
     foreach ($rawEntry in $rawEntries) {
-        $transformedEntries += ConvertTo-TransformedEntry `
+        $transformedEntries.Add((ConvertTo-TransformedEntry `
             -Entry $rawEntry `
             -ExcludeAttributes $script:excludeAttribute `
             -RedactAttributes $script:redactAttribute `
             -HideRedactedCount:$script:hideRedactedValueCount `
             -ScrambleAttributes $script:scrambleAttribute `
-            -ScrambleSeed $script:scrambleRandomSeed
+            -ScrambleSeed $script:scrambleRandomSeed))
     }
 
     $columns = @()
@@ -1353,20 +1354,19 @@ if (-not $baseDN) {
 }
 
 # --- Build search specs ---
-$searchSpecs = @()
+$searchSpecs = [System.Collections.Generic.List[hashtable]]::new()
 
 if ($ldapURLFile) {
-    $searchSpecs += Read-SearchSpecsFromLdapURLFile -Path $ldapURLFile
+    foreach ($s in (Read-SearchSpecsFromLdapURLFile -Path $ldapURLFile)) { $searchSpecs.Add($s) }
 }
 elseif ($filterFile) {
-    $fileFilters = Read-FiltersFromFile -Path $filterFile
-    foreach ($ff in $fileFilters) {
-        $searchSpecs += @{
+    foreach ($ff in (Read-FiltersFromFile -Path $filterFile)) {
+        $searchSpecs.Add(@{
             baseDN     = $null
             attributes = $null
             scope      = $null
             filter     = $ff
-        }
+        })
     }
 }
 
@@ -1376,23 +1376,23 @@ if ($filter) {
             Write-Error "Invalid LDAP filter syntax: $f"
             exit 1
         }
-        $searchSpecs += @{
+        $searchSpecs.Add(@{
             baseDN     = $null
             attributes = $null
             scope      = $null
             filter     = $f
-        }
+        })
     }
 }
 
 # Default filter if nothing specified
 if ($searchSpecs.Count -eq 0) {
-    $searchSpecs += @{
+    $searchSpecs.Add(@{
         baseDN     = $null
         attributes = $null
         scope      = $null
         filter     = '(objectClass=*)'
-    }
+    })
 }
 
 # --- Validate countEntries with multiple searches ---


### PR DESCRIPTION
## Summary

Code review identified that five functions used PowerShell's `$array += item` pattern inside loops. Because PowerShell arrays are fixed-length, each `+=` allocates a new array and copies all existing elements — making the loop O(n²) in the number of items accumulated.

- **`Read-FiltersFromFile`** — `$filters` → `List[string]`
- **`Read-SearchSpecsFromLdapURLFile`** — `$specs` → `List[hashtable]`
- **`ConvertTo-TransformedEntry`** — per-attribute `$valueList` → `List[string]`
- **`Format-JsonOutput`** — `$objects` → `List[PSCustomObject]`
- **`Invoke-SearchAndOutput`** — `$transformedEntries` → `List[object]` (most impactful: called once per result set, so grows with every LDAP entry returned)
- **Main block `$searchSpecs` loop** — converted to `List[hashtable]`

All public return types are unchanged — callers receive plain arrays via `.ToArray()`. No behaviour change.

## Tests

- **6 new `Write-SearchOutput` format-dispatch tests**: JSON, CSV, delimited (custom `|` delimiter), values-only, LDIF terse (no `version: 1`), and tee-to-stdout. Previously only file-write and dns-only were tested.
- **3 new source-code regression guards** in the `Source-Code Checks` block: assert that `$transformedEntries +=`, `$filters +=`, and `$specs +=` don't reappear, preventing an accidental revert of the fixes.

## CI

Touches `psldap.ps1` and `psldap.Tests.ps1`, so `tests.yml` will run the full suite.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013LZWXDE1Aa1NYJdgfnrQGj

---
_Generated by [Claude Code](https://claude.ai/code/session_013LZWXDE1Aa1NYJdgfnrQGj)_